### PR TITLE
Add classloader to Parcel.readStack to avoid using the default one

### DIFF
--- a/common/src/main/java/com/schibsted/account/common/util/Util.kt
+++ b/common/src/main/java/com/schibsted/account/common/util/Util.kt
@@ -55,9 +55,9 @@ fun String.safeUrl(): String {
     return domain + hiddenParams
 }
 
-fun <T> Parcel.readStack(): Stack<T> {
+fun <T> Parcel.readStack(loader: ClassLoader): Stack<T> {
     val items = mutableListOf<T>()
-    this.readList(items, null)
+    this.readList(items, loader)
     return Stack<T>().apply { addAll(items) }
 }
 

--- a/core/src/main/java/com/schibsted/account/engine/controller/Controller.kt
+++ b/core/src/main/java/com/schibsted/account/engine/controller/Controller.kt
@@ -6,17 +6,17 @@ package com.schibsted.account.engine.controller
 
 import android.os.Parcel
 import android.os.Parcelable
-import com.schibsted.account.engine.integration.contract.Contract
-import com.schibsted.account.engine.step.Step
 import com.schibsted.account.common.util.Logger
 import com.schibsted.account.common.util.readStack
+import com.schibsted.account.engine.integration.contract.Contract
+import com.schibsted.account.engine.step.Step
 import java.util.Stack
 
 abstract class Controller<in T : Contract<*>>() : Parcelable {
     internal val navigation: Stack<Step> = Stack()
 
     protected constructor(parcel: Parcel) : this() {
-        val inStack = parcel.readStack<Step>()
+        val inStack = parcel.readStack<Step>(Controller::class.java.classLoader)
         navigation.addAll(inStack)
     }
 

--- a/core/src/main/java/com/schibsted/account/engine/controller/LoginController.kt
+++ b/core/src/main/java/com/schibsted/account/engine/controller/LoginController.kt
@@ -6,6 +6,7 @@ package com.schibsted.account.engine.controller
 
 import android.os.Parcel
 import android.os.Parcelable
+import com.schibsted.account.common.util.readStack
 import com.schibsted.account.engine.input.Credentials
 import com.schibsted.account.engine.integration.CallbackProvider
 import com.schibsted.account.engine.integration.ResultCallback
@@ -19,7 +20,6 @@ import com.schibsted.account.model.LoginResult
 import com.schibsted.account.model.error.ClientError
 import com.schibsted.account.network.OIDCScope
 import com.schibsted.account.session.User
-import com.schibsted.account.common.util.readStack
 
 /**
  * Controller which administrates the process of a login flow using credentials. This is
@@ -33,7 +33,7 @@ class LoginController @JvmOverloads constructor(private val verifyUser: Boolean,
     @OIDCScope private val scopes: Array<String> = arrayOf(OIDCScope.SCOPE_OPENID)) : VerificationController<LoginContract>() {
 
     constructor(parcel: Parcel) : this(parcel.readInt() != 0, parcel.createStringArray()) {
-        super.navigation.addAll(parcel.readStack())
+        super.navigation.addAll(parcel.readStack(LoginController::class.java.classLoader))
     }
 
     override fun evaluate(contract: LoginContract) {

--- a/core/src/main/java/com/schibsted/account/engine/controller/PasswordlessController.kt
+++ b/core/src/main/java/com/schibsted/account/engine/controller/PasswordlessController.kt
@@ -43,7 +43,7 @@ class PasswordlessController @JvmOverloads constructor(private val verifyUser: B
         parcel.readInt() != 0,
         Locale(parcel.readString()),
         parcel.createStringArray()) {
-        super.navigation.addAll(parcel.readStack())
+        super.navigation.addAll(parcel.readStack(PasswordlessController::class.java.classLoader))
     }
 
     override fun evaluate(contract: PasswordlessContract) {

--- a/core/src/main/java/com/schibsted/account/engine/controller/SignUpController.kt
+++ b/core/src/main/java/com/schibsted/account/engine/controller/SignUpController.kt
@@ -37,7 +37,7 @@ import java.net.URI
  */
 class SignUpController(private val baseRedirectUri: URI) : Controller<SignUpContract>() {
     constructor(parcel: Parcel) : this(URI.create(parcel.readString())) {
-        this.navigation.addAll(parcel.readStack())
+        this.navigation.addAll(parcel.readStack(SignUpController::class.java.classLoader))
     }
 
     override fun evaluate(contract: SignUpContract) {

--- a/core/src/main/java/com/schibsted/account/engine/step/StepNoPwIdentify.kt
+++ b/core/src/main/java/com/schibsted/account/engine/step/StepNoPwIdentify.kt
@@ -13,7 +13,7 @@ import com.schibsted.account.network.response.PasswordlessToken
 data class StepNoPwIdentify(val identifier: Identifier,
     val passwordlessToken: PasswordlessToken,
     val isNewUser: Boolean,
-    val agreementLinks: AgreementLinksResponse) : Step(), Parcelable {
+    val agreementLinks: AgreementLinksResponse) : Step() {
 
     constructor(source: Parcel) : this(
         source.readParcelable<Identifier>(Identifier::class.java.classLoader),


### PR DESCRIPTION
When using a default class loader reading a Parcel object fails.
How to reproduce : 
1- Take any samsung device (of course)
2- launch a passwordless flow
3- go to the verification screen
4 - trigger onPause()/onResume() by clicking on the task manager button
Hurra, app will crash onResume when trying to read the parcel.