### PR TITLE
Change identification screen UI

### DIFF
--- a/ui/src/main/res/drawable/schacc_rounded_container.xml
+++ b/ui/src/main/res/drawable/schacc_rounded_container.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2018 Schibsted Products & Technology AS. Licensed under the terms of the MIT license. See LICENSE in the project root.
+  -->
+
+
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <!-- Drop Shadow Stack -->
+    <item>
+        <shape>
+            <padding android:top="1dp" />
+
+            <solid android:color="#00CCCCCC" />
+
+            <corners android:radius="@dimen/schacc_container_radius" />
+        </shape>
+    </item>
+    <item>
+        <shape>
+            <padding android:top="1dp" />
+            <solid android:color="@color/schacc_veryLightBlack" />
+            <corners android:radius="@dimen/schacc_container_radius" />
+        </shape>
+    </item>
+    <item>
+        <shape>
+            <padding android:top="1dp" />
+            <solid android:color="@color/schacc_lightBlack" />
+            <corners android:radius="@dimen/schacc_container_radius" />
+        </shape>
+    </item>
+    <item>
+        <shape>
+            <padding android:top="1dp" />
+            <solid android:color="@color/schacc_lightDarkGrey" />
+            <corners android:radius="@dimen/schacc_container_radius" />
+        </shape>
+    </item>
+    <item>
+        <shape>
+            <padding android:top="1dp" />
+            <solid android:color="@color/schacc_veryLightDarkGrey" />
+            <corners android:radius="@dimen/schacc_container_radius" />
+        </shape>
+    </item>
+
+    <!-- Background -->
+    <item>
+        <shape>
+            <solid android:color="@color/schacc_white" />
+            <corners
+                android:topLeftRadius="@dimen/schacc_container_radius"
+                android:topRightRadius="@dimen/schacc_container_radius" />
+        </shape>
+    </item>
+</layer-list>
+

--- a/ui/src/main/res/layout-h350dp-land/schacc_abstract_identification_fragment_layout.xml
+++ b/ui/src/main/res/layout-h350dp-land/schacc_abstract_identification_fragment_layout.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (c) 2018 Schibsted Products & Technology AS. Licensed under the terms of the MIT license. See LICENSE in the project root.
   -->
 
@@ -7,7 +6,9 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/identification_container"
-    style="@style/schacc_container">
+    android:theme="@color/schacc_grey"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent">
 
     <TextView
         android:id="@+id/schacc_teaser_text"
@@ -26,45 +27,53 @@
         tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce malesuada tristique dolor, vel lacinia justo semper eget. Curabitur non urna non felis tincidunt faucibus at non dui." />
 
     <FrameLayout
-        android:id="@+id/identification_input_view"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/schacc_teaser_text" />
-
-    <TextView
-        android:id="@+id/identification_share_policy"
-        style="@style/schacc_text.secondary"
-        android:layout_marginTop="20dp"
-        android:drawableLeft="@drawable/schacc_ic_lock_outline"
-        android:drawablePadding="16dp"
-        android:drawableStart="@drawable/schacc_ic_lock_outline"
-        app:layout_constraintTop_toBottomOf="@+id/identification_input_view"
-        tools:layout_conversion_absoluteHeight="17dp"
-        tools:layout_conversion_absoluteWidth="18dp"
-        tools:layout_conversion_absoluteX="0dp"
-        tools:layout_conversion_absoluteY="3dp" />
-
-    <TextView
-        android:id="@+id/help_link"
-        style="@style/schacc_text.link"
-        android:layout_marginStart="40dp"
-        android:layout_marginLeft="40dp"
-        android:text="@string/schacc_identification_help_link_text"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/identification_share_policy" />
-
-    <com.schibsted.account.ui.ui.component.LoadingButton
-        android:id="@+id/identification_button_continue"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:text="@string/schacc_next_step"
+        android:layout_height="0dp"
+        android:background="@drawable/schacc_rounded_container"
         app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/schacc_teaser_text"
         app:layout_constraintStart_toStartOf="parent"
-        tools:layout_conversion_absoluteHeight="48dp"
-        tools:layout_conversion_absoluteWidth="352dp"
-        tools:layout_conversion_absoluteX="0dp"
-        tools:layout_conversion_absoluteY="439dp" />
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <android.support.constraint.ConstraintLayout
+            style="@style/schacc_container"
+            android:paddingTop="24dp"
+            android:paddingBottom="0dp">
+
+            <FrameLayout
+                android:id="@+id/identification_input_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent" />
+
+            <TextView
+                android:id="@+id/identification_share_policy"
+                style="@style/schacc_text.secondary"
+                android:layout_marginTop="20dp"
+                android:drawableLeft="@drawable/schacc_ic_lock_outline"
+                android:drawablePadding="16dp"
+                android:drawableStart="@drawable/schacc_ic_lock_outline"
+                app:layout_constraintTop_toBottomOf="@+id/identification_input_view" />
+
+            <TextView
+                android:id="@+id/help_link"
+                style="@style/schacc_text.link"
+                android:layout_marginStart="40dp"
+                android:layout_marginLeft="40dp"
+                android:text="@string/schacc_identification_help_link_text"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/identification_share_policy" />
+
+            <com.schibsted.account.ui.ui.component.LoadingButton
+                android:id="@+id/identification_button_continue"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:text="@string/schacc_next_step"
+                android:layout_marginBottom="16dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent" />
+        </android.support.constraint.ConstraintLayout>
+    </FrameLayout>
 </android.support.constraint.ConstraintLayout>

--- a/ui/src/main/res/layout-land/schacc_abstract_identification_fragment_layout.xml
+++ b/ui/src/main/res/layout-land/schacc_abstract_identification_fragment_layout.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (c) 2018 Schibsted Products & Technology AS. Licensed under the terms of the MIT license. See LICENSE in the project root.
   -->
 
@@ -7,7 +6,9 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/identification_container"
-    style="@style/schacc_container">
+    android:theme="@color/schacc_grey"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent">
 
     <TextView
         android:id="@+id/schacc_teaser_text"
@@ -26,41 +27,53 @@
         tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce malesuada tristique dolor, vel lacinia justo semper eget. Curabitur non urna non felis tincidunt faucibus at non dui." />
 
     <FrameLayout
-        android:id="@+id/identification_input_view"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_height="0dp"
+        android:background="@drawable/schacc_rounded_container"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/schacc_teaser_text"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/schacc_teaser_text" />
+        app:layout_constraintEnd_toEndOf="parent">
 
-    <TextView
-        android:id="@+id/identification_share_policy"
-        style="@style/schacc_text.secondary"
-        android:layout_marginTop="20dp"
-        android:drawableLeft="@drawable/schacc_ic_lock_outline"
-        android:drawablePadding="16dp"
-        android:drawableStart="@drawable/schacc_ic_lock_outline"
-        app:layout_constraintTop_toBottomOf="@+id/identification_input_view"
-        tools:layout_conversion_absoluteHeight="17dp"
-        tools:layout_conversion_absoluteWidth="18dp"
-        tools:layout_conversion_absoluteX="0dp"
-        tools:layout_conversion_absoluteY="3dp" />
+        <android.support.constraint.ConstraintLayout
+            style="@style/schacc_container"
+            android:paddingTop="24dp"
+            android:paddingBottom="0dp">
 
-    <TextView
-        android:id="@+id/help_link"
-        style="@style/schacc_text.link"
-        android:layout_marginStart="40dp"
-        android:layout_marginLeft="40dp"
-        android:text="@string/schacc_identification_help_link_text"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/identification_share_policy" />
+            <FrameLayout
+                android:id="@+id/identification_input_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent" />
 
-    <com.schibsted.account.ui.ui.component.LoadingButton
-        android:id="@+id/identification_button_continue"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:text="@string/schacc_next_step"
-        app:layout_constraintTop_toBottomOf="@+id/help_link"
-        android:layout_marginTop="16dp" />
+            <TextView
+                android:id="@+id/identification_share_policy"
+                style="@style/schacc_text.secondary"
+                android:layout_marginTop="20dp"
+                android:drawableLeft="@drawable/schacc_ic_lock_outline"
+                android:drawablePadding="16dp"
+                android:drawableStart="@drawable/schacc_ic_lock_outline"
+                app:layout_constraintTop_toBottomOf="@+id/identification_input_view" />
+
+            <TextView
+                android:id="@+id/help_link"
+                style="@style/schacc_text.link"
+                android:layout_marginStart="40dp"
+                android:layout_marginLeft="40dp"
+                android:text="@string/schacc_identification_help_link_text"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/identification_share_policy" />
+
+            <com.schibsted.account.ui.ui.component.LoadingButton
+                android:id="@+id/identification_button_continue"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:text="@string/schacc_next_step"
+                app:layout_constraintTop_toBottomOf="@+id/help_link"
+                android:layout_marginBottom="16dp"
+                android:layout_marginTop="16dp" />
+        </android.support.constraint.ConstraintLayout>
+    </FrameLayout>
 </android.support.constraint.ConstraintLayout>

--- a/ui/src/main/res/layout/schacc_abstract_identification_fragment_layout.xml
+++ b/ui/src/main/res/layout/schacc_abstract_identification_fragment_layout.xml
@@ -6,7 +6,9 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/identification_container"
-    style="@style/schacc_container">
+    android:theme="@color/schacc_grey"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent">
 
     <TextView
         android:id="@+id/schacc_teaser_text"
@@ -25,45 +27,53 @@
         tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce malesuada tristique dolor, vel lacinia justo semper eget. Curabitur non urna non felis tincidunt faucibus at non dui." />
 
     <FrameLayout
-        android:id="@+id/identification_input_view"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/schacc_teaser_text" />
-
-    <TextView
-        android:id="@+id/identification_share_policy"
-        style="@style/schacc_text.secondary"
-        android:layout_marginTop="20dp"
-        android:drawableLeft="@drawable/schacc_ic_lock_outline"
-        android:drawablePadding="16dp"
-        android:drawableStart="@drawable/schacc_ic_lock_outline"
-        app:layout_constraintTop_toBottomOf="@+id/identification_input_view"
-        tools:layout_conversion_absoluteHeight="17dp"
-        tools:layout_conversion_absoluteWidth="18dp"
-        tools:layout_conversion_absoluteX="0dp"
-        tools:layout_conversion_absoluteY="3dp" />
-
-    <TextView
-        android:id="@+id/help_link"
-        style="@style/schacc_text.link"
-        android:layout_marginLeft="40dp"
-        android:layout_marginStart="40dp"
-        android:text="@string/schacc_identification_help_link_text"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/identification_share_policy" />
-
-    <com.schibsted.account.ui.ui.component.LoadingButton
-        android:id="@+id/identification_button_continue"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="0dp"
+        android:background="@drawable/schacc_rounded_container"
         app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/schacc_teaser_text"
         app:layout_constraintStart_toStartOf="parent"
-        app:text="@string/schacc_next_step"
-        tools:layout_conversion_absoluteHeight="48dp"
-        tools:layout_conversion_absoluteWidth="352dp"
-        tools:layout_conversion_absoluteX="0dp"
-        tools:layout_conversion_absoluteY="439dp" />
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <android.support.constraint.ConstraintLayout
+            style="@style/schacc_container"
+            android:paddingTop="24dp"
+            android:paddingBottom="0dp">
+
+            <FrameLayout
+                android:id="@+id/identification_input_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent" />
+
+            <TextView
+                android:id="@+id/identification_share_policy"
+                style="@style/schacc_text.secondary"
+                android:layout_marginTop="20dp"
+                android:drawableLeft="@drawable/schacc_ic_lock_outline"
+                android:drawablePadding="16dp"
+                android:drawableStart="@drawable/schacc_ic_lock_outline"
+                app:layout_constraintTop_toBottomOf="@+id/identification_input_view" />
+
+            <TextView
+                android:id="@+id/help_link"
+                style="@style/schacc_text.link"
+                android:layout_marginLeft="40dp"
+                android:layout_marginStart="40dp"
+                android:text="@string/schacc_identification_help_link_text"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/identification_share_policy" />
+
+            <com.schibsted.account.ui.ui.component.LoadingButton
+                android:id="@+id/identification_button_continue"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:text="@string/schacc_next_step"
+                android:layout_marginBottom="16dp" />
+        </android.support.constraint.ConstraintLayout>
+    </FrameLayout>
 </android.support.constraint.ConstraintLayout>

--- a/ui/src/main/res/values/colors.xml
+++ b/ui/src/main/res/values/colors.xml
@@ -26,13 +26,17 @@
     <color name="schacc_error">#c8293d</color>
     <color name="schacc_lightError">#0dd13649</color>
 
+    <color name="schacc_veryLightBlack">#10CCCCCC</color>
+    <color name="schacc_lightBlack">#20CCCCCC</color>
+    <color name="schacc_lightDarkGrey">#30CCCCCC</color>
+    <color name="schacc_veryLightDarkGrey">#50CCCCCC</color>
     <color name="schacc_darkGrey">#666666</color>
     <color name="schacc_mediumGrey">#b6b6b6</color>
+    <color name="schacc_grey">#f3f3f3</color>
     <color name="schacc_lightGrey">#eaeaea</color>
     <color name="schacc_veryLightGrey">#f8f8f8</color>
 
     <color name="schacc_black">#111</color>
     <color name="schacc_green">#498A02</color>
     <color name="schacc_white">#ffffff</color>
-
 </resources>

--- a/ui/src/main/res/values/dimens.xml
+++ b/ui/src/main/res/values/dimens.xml
@@ -19,4 +19,5 @@
     <dimen name="schacc_checkbox_padding">14dp</dimen>
     <dimen name="schacc_activity_top_padding">40dp</dimen>
     <dimen name="schacc_secondary_text_size">14sp</dimen>
+    <dimen name="schacc_container_radius">12dp</dimen>
 </resources>

--- a/ui/src/main/res/values/styles.xml
+++ b/ui/src/main/res/values/styles.xml
@@ -19,7 +19,7 @@
         <item name="windowNoTitle">true</item>
         <item name="windowActionBarOverlay">false</item>
     </style>
-    
+
     <style name="schacc_progressBar">
         <item name="colorAccent">@color/schacc_progressColor</item>
     </style>


### PR DESCRIPTION
New identification UI, the new teaser text isn't included, because there's another ticket for it in progress and assigned to @Nexcius . I didn't want to redo what you might have already done :)
See the following attachement

![new_ui](https://user-images.githubusercontent.com/18486684/37295993-f390f4a8-2619-11e8-937f-957d545387c2.png)
