### PR TITLE
Change behavior to set the language of the application dependending on the uiConfiguration

### DIFF
--- a/example/src/main/java/com/schibsted/account/example/MainActivity.java
+++ b/example/src/main/java/com/schibsted/account/example/MainActivity.java
@@ -54,6 +54,7 @@ public class MainActivity extends AppCompatActivity {
         final UiConfiguration uiConfiguration = UiConfiguration.Builder.fromManifest(getApplicationContext())
                 .enableSignUp()
                 .logo(R.drawable.ic_example_logo)
+                .locale(new Locale("nb", "NO"))
                 .teaserText(getString(R.string.example_teaser_text))
                 .build();
 

--- a/ui/src/main/java/com/schibsted/account/ui/UiUtil.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/UiUtil.kt
@@ -4,9 +4,10 @@
 
 package com.schibsted.account.ui
 
+import android.content.Context
 import com.schibsted.account.common.tracking.TrackingData
-import com.schibsted.account.engine.input.Identifier
 import com.schibsted.account.ui.login.screen.LoginScreen
+import java.util.Locale
 
 object UiUtil {
     @JvmStatic
@@ -21,8 +22,10 @@ object UiUtil {
     }
 
     @JvmStatic
-    fun getTrackerIdType(idType: Identifier.IdentifierType): TrackingData.IdentifierType = when (idType) {
-        Identifier.IdentifierType.EMAIL -> TrackingData.IdentifierType.EMAIL
-        Identifier.IdentifierType.SMS -> TrackingData.IdentifierType.PHONE
+    fun setLanguage(context: Context, locale: Locale) {
+        val resources = context.resources
+        val conf = resources.configuration
+        conf.locale = locale
+        resources.updateConfiguration(conf, resources.displayMetrics)
     }
 }

--- a/ui/src/main/java/com/schibsted/account/ui/login/BaseLoginActivity.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/login/BaseLoginActivity.kt
@@ -36,6 +36,7 @@ import com.schibsted.account.session.User
 import com.schibsted.account.ui.KeyboardManager
 import com.schibsted.account.ui.R
 import com.schibsted.account.ui.UiConfiguration
+import com.schibsted.account.ui.UiUtil
 import com.schibsted.account.ui.login.flow.password.FlowSelectionListener
 import com.schibsted.account.ui.login.flow.password.LoginContractImpl
 import com.schibsted.account.ui.login.screen.LoginScreen
@@ -130,6 +131,7 @@ abstract class BaseLoginActivity : AppCompatActivity(), KeyboardManager, Navigat
         setContentView(R.layout.schacc_mobile_activity_layout)
         setUpActionBar()
         activityRoot = findViewById(R.id.activity_layout)
+        UiUtil.setLanguage(this, uiConfiguration.locale)
     }
 
     private fun initializeUiConfiguration() {


### PR DESCRIPTION
Fixes #43 
I do know that this method is deprecated but we can't use the new one. The new one gives us a context to set in `attachBaseContext` unfortunately when this method is called it's too early to create/get the `UIConfiguration`. (I tried it with the following function)

```
    @JvmStatic
    fun getContext(context: Context, locale: Locale): ContextWrapper {
        val resources = context.resources
        var newContext = context
        val conf = resources.configuration
        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
            conf.setLocale(locale)
            newContext = context.createConfigurationContext(conf)
        } else {
            conf.locale = locale
            resources.updateConfiguration(conf, resources.displayMetrics)
        }
        return ContextWrapper(newContext)
    }
```