### PR TITLE
Change identification layout to avoid keyboard to show up

### DIFF
--- a/ui/src/main/res/layout-h350dp-land/schacc_abstract_identification_fragment_layout.xml
+++ b/ui/src/main/res/layout-h350dp-land/schacc_abstract_identification_fragment_layout.xml
@@ -72,6 +72,7 @@
 
             <FrameLayout
                 android:id="@+id/identification_input_view"
+                android:focusable="true"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"

--- a/ui/src/main/res/layout-land/schacc_abstract_identification_fragment_layout.xml
+++ b/ui/src/main/res/layout-land/schacc_abstract_identification_fragment_layout.xml
@@ -72,6 +72,7 @@
 
             <FrameLayout
                 android:id="@+id/identification_input_view"
+                android:focusable="true"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"

--- a/ui/src/main/res/layout/schacc_abstract_identification_fragment_layout.xml
+++ b/ui/src/main/res/layout/schacc_abstract_identification_fragment_layout.xml
@@ -74,6 +74,7 @@
 
             <FrameLayout
                 android:id="@+id/identification_input_view"
+                android:focusable="true"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"


### PR DESCRIPTION
On the identification screen: sometimes the keyboard get time to quickly show up before we close it down, giving the focus to a not editable field resolve that behaviour