### PR TITLE
Fix keyboard behavior

### DIFF
--- a/ui/src/main/java/com/schibsted/account/ui/login/BaseLoginActivity.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/login/BaseLoginActivity.kt
@@ -330,7 +330,7 @@ abstract class BaseLoginActivity : AppCompatActivity(), KeyboardManager, Navigat
      */
     override fun closeKeyboard() {
         val imm = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-        imm.hideSoftInputFromWindow(window.decorView.windowToken, InputMethodManager.HIDE_IMPLICIT_ONLY)
+        imm.hideSoftInputFromWindow(window.decorView.windowToken, 0)
     }
 
     private fun updateActionBar() {

--- a/ui/src/main/java/com/schibsted/account/ui/ui/BaseFragment.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/ui/BaseFragment.kt
@@ -55,7 +55,6 @@ abstract class BaseFragment : Fragment(), Animation.AnimationListener {
     }
 
     override fun onAnimationEnd(animation: Animation?) {
-        keyboardManager.closeKeyboard()
     }
 
     override fun onAnimationRepeat(animation: Animation?) {

--- a/ui/src/main/java/com/schibsted/account/ui/ui/FlowFragment.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/ui/FlowFragment.kt
@@ -69,5 +69,6 @@ abstract class FlowFragment<in T> : BaseFragment(), KeyboardVisibilityListener, 
 
     override fun showProgress() {
         primaryActionView.showProgress()
+        keyboardManager.closeKeyboard()
     }
 }

--- a/ui/src/main/res/layout-h350dp-land/schacc_abstract_identification_fragment_layout.xml
+++ b/ui/src/main/res/layout-h350dp-land/schacc_abstract_identification_fragment_layout.xml
@@ -72,6 +72,8 @@
 
             <FrameLayout
                 android:id="@+id/identification_input_view"
+                android:focusable="true"
+                android:focusableInTouchMode="true"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"

--- a/ui/src/main/res/layout-h350dp-land/schacc_verification_fragment_layout.xml
+++ b/ui/src/main/res/layout-h350dp-land/schacc_verification_fragment_layout.xml
@@ -22,6 +22,7 @@
         style="@style/schacc_text.label"
         android:layout_below="@id/identifier_modifier"
         android:layout_marginTop="24dp"
+        android:textIsSelectable="true"
         android:text="@string/schacc_verification_code_label"/>
 
     <com.schibsted.account.ui.ui.component.CodeInputView

--- a/ui/src/main/res/layout-land/schacc_abstract_identification_fragment_layout.xml
+++ b/ui/src/main/res/layout-land/schacc_abstract_identification_fragment_layout.xml
@@ -72,6 +72,8 @@
 
             <FrameLayout
                 android:id="@+id/identification_input_view"
+                android:focusable="true"
+                android:focusableInTouchMode="true"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"

--- a/ui/src/main/res/layout-land/schacc_verification_fragment_layout.xml
+++ b/ui/src/main/res/layout-land/schacc_verification_fragment_layout.xml
@@ -22,6 +22,7 @@
         style="@style/schacc_text.label"
         android:layout_below="@id/identifier_modifier"
         android:layout_marginTop="24dp"
+        android:textIsSelectable="true"
         android:text="@string/schacc_verification_code_label"/>
 
     <com.schibsted.account.ui.ui.component.CodeInputView

--- a/ui/src/main/res/layout/schacc_abstract_identification_fragment_layout.xml
+++ b/ui/src/main/res/layout/schacc_abstract_identification_fragment_layout.xml
@@ -69,16 +69,19 @@
 
         <android.support.constraint.ConstraintLayout
             style="@style/schacc_container"
+            android:focusable="true"
             android:paddingTop="24dp"
             android:paddingBottom="0dp">
 
             <FrameLayout
                 android:id="@+id/identification_input_view"
+                android:focusable="true"
+                android:focusableInTouchMode="true"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent" />
+                app:layout_constraintStart_toStartOf="parent"/>
 
             <TextView
                 android:id="@+id/identification_share_policy"

--- a/ui/src/main/res/layout/schacc_verification_fragment_layout.xml
+++ b/ui/src/main/res/layout/schacc_verification_fragment_layout.xml
@@ -22,6 +22,7 @@
         style="@style/schacc_text.label"
         android:layout_below="@id/identifier_modifier"
         android:layout_marginTop="24dp"
+        android:textIsSelectable="true"
         android:text="@string/schacc_verification_code_label"/>
 
     <com.schibsted.account.ui.ui.component.CodeInputView


### PR DESCRIPTION
Don't show keyboard when a new screen is displayed, and close it as soon as the action is performed if the provided input is valid (if not we don't show the continue button either the loading hint, it seems like the app is frozen)