### PR TITLE
Move functions for session handling to the User class

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -70,20 +70,13 @@ public class MyActivity extends AppCompatActivity {
 ```
 
 ### Resuming user sessions
-You can manage user sessions by using the `UserPersistence` class. This allows you to resume sessions, remove sessions and manually persist them.
+You can manage user sessions by using the static functions of the `User` class. Normal use cases are usually limited to resuming sessions, but it's also possible to remove previous sessions or clear all sessions. Please note that if your intention is to log out the user, you should call `user.logout(...)` to ensure the tokens are invalidated with the back-end.
 
 __Example__
 ```java
-UserPersistence persistence = new UserPersistence(getApplicationContext());
+User user = User.resumeSession(context, myUserId, new new ResultCallback<User>() { ... })
 
-// Resuming a specific session
-User resumedUser = persistence.resume("someUserId-123");
-
-// Resuming the last session
-User lastUser = persistence.resumeLast();
-
-// Remove user form persistence (should be done on logout etc)
-persistence.remove("someUserId-123");
+User user = User.resumeLastSession(context, new new ResultCallback<User>() { ... })
 ```
 
 ### Logging out

--- a/core/src/main/java/com/schibsted/account/persistence/UserPersistence.kt
+++ b/core/src/main/java/com/schibsted/account/persistence/UserPersistence.kt
@@ -20,26 +20,10 @@ import com.schibsted.account.model.error.ClientError
  * a specific user's session if required.
  * @param appContext The application context
  */
-class UserPersistence(private val appContext: Context) {
+internal class UserPersistence(private val appContext: Context) {
     internal data class Session(val lastActive: Long, val userId: String, val token: UserToken)
 
     private var sessions: List<Session> by SessionStorageDelegate(appContext, PREFERENCE_FILENAME, SAVED_SESSIONS_KEY)
-
-    /**
-     * Resume a specific user's session. The session will be resumed and the required checks will
-     * be done before a user object is returned through the contract
-     * @param userId The user ID of the session to resume
-     * @return The user object of the resumed session. Can be null
-     */
-    @Deprecated("Deprecated due to GDPR compatibility where we needed to verify that the user had accepted agreements",
-            ReplaceWith("this.resume(userId, object : ResultCallback<User> {})"))
-    fun resume(userId: String): User? {
-        val session = sessions.find { it.userId == userId }
-
-        return session?.let {
-            User(it.token, true)
-        }
-    }
 
     /**
      * Resume a specific user's session. The session will be resumed and the required checks will
@@ -57,21 +41,6 @@ class UserPersistence(private val appContext: Context) {
             user.agreements.ensureAccepted(ResultCallback.fromLambda({ callback.onError(it) }) {
                 callback.onSuccess(user)
             })
-        }
-    }
-
-    /**
-     * Resume the most recently active user session. The session will be resumed and the required checks will
-     * be done before a user object is returned through the contract
-     * @return The user object of the resumed session. Can be null
-     */
-    @Deprecated("Deprecated due to GDPR compatibility where we needed to verify that the user had accepted agreements",
-            ReplaceWith("this.resumeLast(object : ResultCallback<User> {})"))
-    fun resumeLast(): User? {
-        val lastActiveSession = sessions.sortedByDescending { it.lastActive }.firstOrNull()?.token ?: readTokenCompat()
-
-        return lastActiveSession?.let {
-            User(it, true)
         }
     }
 

--- a/core/src/main/java/com/schibsted/account/session/User.kt
+++ b/core/src/main/java/com/schibsted/account/session/User.kt
@@ -4,6 +4,7 @@
 
 package com.schibsted.account.session
 
+import android.content.Context
 import android.content.Intent
 import android.os.Parcel
 import android.os.Parcelable
@@ -23,6 +24,7 @@ import com.schibsted.account.network.InfoInterceptor
 import com.schibsted.account.network.NetworkCallback
 import com.schibsted.account.network.ServiceHolder
 import com.schibsted.account.network.response.TokenResponse
+import com.schibsted.account.persistence.UserPersistence
 import okhttp3.OkHttpClient
 
 /**
@@ -178,6 +180,54 @@ class User(token: UserToken, val isPersistable: Boolean) : Parcelable {
                                 })
                             }
                     ))
+        }
+
+        /**
+         * Resumes the last active user's session. This verifies that the user has accepted terms
+         * and that all required fields are provided. If this fails, onError will be called
+         * @param callback The callback for which to return the result
+         */
+        @JvmStatic
+        fun resumeLastSession(appContext: Context, callback: ResultCallback<User>) {
+            UserPersistence(appContext).resumeLast(callback)
+        }
+
+        /**
+         * Resumes the last active user's session. This verifies that the user has accepted terms
+         * and that all required fields are provided. If this fails, onError will be called. If no
+         * session is found for the user id, onError will be called.
+         * @param userId The ID of the user to resume a session for
+         * @param callback The callback for which to return the result
+         */
+        @JvmStatic
+        fun resumeSession(appContext: Context, userId: String, callback: ResultCallback<User>) {
+            UserPersistence(appContext).resume(userId, callback)
+        }
+
+        /**
+         * Removes the last user's session, causing it not be be able to be resumed. If your purpose is
+         * to to log out the user, call [User.logout] instead.
+         */
+        @JvmStatic
+        fun removeLastSession(appContext: Context) {
+            UserPersistence(appContext).removeLast()
+        }
+
+        /**
+         * Removes a user's session, causing it not be be able to be resumed. If your purpose is
+         * to to log out the user, call [User.logout] instead.
+         */
+        @JvmStatic
+        fun removeSession(appContext: Context, userId: String) {
+            UserPersistence(appContext).remove(userId)
+        }
+
+        /**
+         * Clears all stored user sessions
+         */
+        @JvmStatic
+        fun removeAllSession(appContext: Context) {
+            UserPersistence(appContext).removeAll()
         }
     }
 }

--- a/core/src/test/java/com/schibsted/account/session/UserPersistenceTest.kt
+++ b/core/src/test/java/com/schibsted/account/session/UserPersistenceTest.kt
@@ -15,15 +15,14 @@ import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.spy
 import com.nhaarman.mockito_kotlin.whenever
 import com.schibsted.account.ClientConfiguration
+import com.schibsted.account.common.util.Logger
 import com.schibsted.account.model.UserToken
 import com.schibsted.account.network.Environment
 import com.schibsted.account.persistence.UserPersistence
 import com.schibsted.account.test.TestUtil
-import com.schibsted.account.common.util.Logger
 import io.kotlintest.matchers.haveSubstring
 import io.kotlintest.matchers.should
 import io.kotlintest.matchers.shouldBe
-import io.kotlintest.matchers.shouldNotBe
 import io.kotlintest.specs.BehaviorSpec
 
 class UserPersistenceTest : BehaviorSpec({
@@ -58,23 +57,6 @@ class UserPersistenceTest : BehaviorSpec({
     doNothing().whenever(userPersistence).clearTokenCompat()
 
     Given("A fresh UserPersistence instance") {
-        When("storing a user which is persistable") {
-            val user = User(UserToken(null, "myUser", "accessToken", "refreshToken", "scope", "type", 123), true)
-            userPersistence.persist(user)
-
-            Then("it should be retrieved successfully using the resumeLast function") {
-                val res = userPersistence.resumeLast()
-                res shouldNotBe null
-                res!!.userId.id shouldBe "myUser"
-            }
-
-            Then("it should be successfully retrieved using the user id") {
-                val res = userPersistence.resume("myUser")
-                res shouldNotBe null
-                res!!.userId.id shouldBe "myUser"
-            }
-        }
-
         When("the user is not persistable") {
             val user = User(UserToken(null, "myUser", "accessToken", "refreshToken", "scope", "type", 123), false)
 

--- a/example/src/main/java/com/schibsted/account/example/MainActivity.java
+++ b/example/src/main/java/com/schibsted/account/example/MainActivity.java
@@ -23,7 +23,6 @@ import com.schibsted.account.Events;
 import com.schibsted.account.engine.integration.ResultCallback;
 import com.schibsted.account.model.error.ClientError;
 import com.schibsted.account.network.response.ProfileData;
-import com.schibsted.account.persistence.UserPersistence;
 import com.schibsted.account.session.User;
 import com.schibsted.account.ui.UiConfiguration;
 import com.schibsted.account.ui.login.BaseLoginActivity;
@@ -70,7 +69,7 @@ public class MainActivity extends AppCompatActivity {
         accountSdkReceiver = new AccountSdkReceiver();
 
         // Attempt to resume any previous sessions, that includes sessions coming from deeplink or smartlock
-        new UserPersistence(getApplicationContext()).resumeLast(new ResultCallback<User>() {
+        User.resumeLastSession(getApplicationContext(), new ResultCallback<User>() {
             @Override
             public void onSuccess(User result) {
                 user = result;


### PR DESCRIPTION
Fixes #83 

**Upgrade notes**
- `UserPersistence` is no longer available and its functionality can now be found as static functions on the `User` object. 
-  The deprecated functions for synchronously resuming sessions are now removed to adhere to the GDPR requirements of checking terms when resuming a session. You can resume sessions by providing a callback to the replacement functions.