### PR TITLE
Fix issue where app was crashing when getting Agreements

### DIFF
--- a/core/src/main/java/com/schibsted/account/network/response/AgreementLinksResponse.kt
+++ b/core/src/main/java/com/schibsted/account/network/response/AgreementLinksResponse.kt
@@ -6,24 +6,21 @@ package com.schibsted.account.network.response
 
 import android.os.Parcel
 import android.os.Parcelable
-import com.google.gson.JsonArray
 import com.google.gson.annotations.SerializedName
 
 data class AgreementLinksResponse(@SerializedName("accepted") private val accepted: Boolean,
                                   @SerializedName("terms_url") val clientTermsUrl: String,
                                   @SerializedName("privacy_url") val clientPrivacyUrl: String,
                                   @SerializedName("platform_terms_url") val spidTermsUrl: String,
-                                  @SerializedName("summary") private val summary: JsonArray,
+                                  @SerializedName("summary") val summary: String,
                                   @SerializedName("platform_privacy_url") val spidPrivacyUrl: String) : Parcelable {
-
-    val summaryText: String get() = if (summary.size() > 0) summary.get(0).asString else ""
 
     constructor(source: Parcel) : this(
         1 == source.readInt(),
         source.readString(),
         source.readString(),
         source.readString(),
-        source.readJsonArray(),
+        source.readString(),
         source.readString()
     )
 
@@ -34,7 +31,7 @@ data class AgreementLinksResponse(@SerializedName("accepted") private val accept
         writeString(clientTermsUrl)
         writeString(clientPrivacyUrl)
         writeString(spidTermsUrl)
-        writeJsonArray(summary)
+        writeString(summary)
         writeString(spidPrivacyUrl)
     }
 
@@ -44,19 +41,5 @@ data class AgreementLinksResponse(@SerializedName("accepted") private val accept
             override fun createFromParcel(source: Parcel): AgreementLinksResponse = AgreementLinksResponse(source)
             override fun newArray(size: Int): Array<AgreementLinksResponse?> = arrayOfNulls(size)
         }
-    }
-}
-
-private fun Parcel.readJsonArray(): JsonArray {
-    val array = JsonArray()
-    array.add(readString())
-    return array
-}
-
-private fun Parcel.writeJsonArray(summary: JsonArray) {
-    if (summary.size() > 0) {
-        writeString(summary.get(0).toString())
-    } else {
-        writeString("")
     }
 }

--- a/ui/src/main/java/com/schibsted/account/ui/login/screen/term/TermsFragment.java
+++ b/ui/src/main/java/com/schibsted/account/ui/login/screen/term/TermsFragment.java
@@ -144,7 +144,7 @@ public class TermsFragment extends FlowFragment<TermsContract.Presenter> impleme
                         tracker.eventEngagement(TrackingData.Engagement.CLICK, TrackingData.UIElement.AGREEMENTS_SUMMARY, TrackingData.Screen.AGREEMENTS);
                     }
 
-                    navigationListener.onDialogNavigationRequested(TermsUpdateDialog.newInstance(agreements.getSummaryText()));
+                    navigationListener.onDialogNavigationRequested(TermsUpdateDialog.newInstance(agreements.getSummary()));
                 }
             }
         });


### PR DESCRIPTION
I was doing some unrelated tests when I got : 
```
NetworkError(code=-1, type=network_error, description=Expected a com.google.gson.JsonArray but was com.google.gson.JsonPrimitive, endpoint=https://identity-pre.schibsted.com/api/2/terms?<hidden>)
```
So doing a test on postman I discovered that `https://identity-pre.schibsted.com/api/2/terms` doesn't return `summary` as an array anymore but now as a string. That's a good change of course but it made the application crash, would have been great to be noticed :thinking: 