### PR TITLE
Fixing lint issue about service registration

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -23,11 +23,6 @@ After a successful login, you get a `User` object. The user object is responsibl
 ### Persisting user sessions
 The SDK provides the `AccountService` which includes the `UserPersistenceService`. This automates persisting and refreshing the stored user on token updates etc as well as logouts. To use this, you should bind this anywhere where your user is active. 
 
-__Note:__ Remember to add this service to your manifest if you're using the `AccountService`.
-```xml
-<service android:name="com.schibsted.account.persistence.UserPersistenceService" />
-```
-
 __Example__
 
 ```java

--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -6,6 +6,8 @@
     package="com.schibsted.account">
 
     <uses-permission android:name="android.permission.INTERNET" />
-
+    <application>
+        <service android:name="com.schibsted.account.persistence.UserPersistenceService" />
+    </application>
 
 </manifest>


### PR DESCRIPTION
If a client try to register the service this error will show up
```
app/src/main/AndroidManifest.xml:16: Error: Class referenced in the manifest, com.schibsted.account.persistence.UserPersistenceService, was not found in the project or the libraries [MissingRegistered]
          <service android:name="com.schibsted.account.persistence.UserPersistenceService" />
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
I first thought of AIDL but as per https://developer.android.com/guide/components/aidl.html it's not required in our case.

> Note: Using AIDL is necessary only if you allow clients from different applications to access your service for IPC and want to handle multithreading in your service. If you do not need to perform concurrent IPC across different applications, you should create your interface by implementing a Binder or, if you want to perform IPC, but do not need to handle multithreading, implement your interface using a Messenger. Regardless, be sure that you understand Bound Services before implementing an AIDL.

Also this commit allow to requires less configuration from the client.
