### PR TITLE
Add failed mode to SmartLock

### DIFF
--- a/example/src/main/java/com/schibsted/account/example/MainActivity.java
+++ b/example/src/main/java/com/schibsted/account/example/MainActivity.java
@@ -150,9 +150,9 @@ public class MainActivity extends AppCompatActivity {
                 updateUi();
 
             } else if (resultCode == SmartlockImpl.SMARTLOCK_FAILED) {
-                //start the flow without smartlock
+                // restart the flow, telling the SDK that SmartLock failed
                 final Intent intent = AccountUi.getCallingIntent(getApplicationContext(), AccountUi.FlowType.PASSWORD,
-                        new AccountUi.Params(getString(R.string.example_teaser_text), null, SmartlockMode.DISABLED, new String[]{OIDCScope.SCOPE_OPENID}));
+                        new AccountUi.Params(getString(R.string.example_teaser_text), null, SmartlockMode.FAILED, new String[]{OIDCScope.SCOPE_OPENID}));
                 startActivityForResult(intent, PASSWORD_REQUEST_CODE);
 
             } else {

--- a/smartlock/README.md
+++ b/smartlock/README.md
@@ -9,8 +9,9 @@ There are three smartlock modes:
 - SmartlockMode.ENABLED: The SDK will attempt to log the user in with smartlock. If it fails but smartlock managed to get the user identifier, the usual login flow will be launched 
 with identifier prefilled. For more information see [google smartlock flow](https://developers.google.com/identity/smartlock-passwords/android/overview)
 - SmartlockMode.FORCED: The SDK will attempt to log user in with and only with smartlock. 
+- SmartlockMode.FAILED: Tell the SDK that you've attempted to log in using smartlock, but that the user cancelled it or the attempt failed. This will allow the user to store new credentials.
 
-In any case of failure you will be notified in `onActivityResult` with the result code `SmartlockImpl.SMARTLOCK_FAILED`. You might want to directly restart the flow, disabling SmartLock for a seamless user experience.
+In any case of failure you will be notified in `onActivityResult` with the result code `SmartlockImpl.SMARTLOCK_FAILED`. You might want to directly restart the flow, choosing to disabl e(`SmartlockMode.DISABLED`) SmartLock or tell the UIs that it failed (`SmartlockMode.FAILED`) for a seamless user experience. The former does not allow the user to store any new credentials, while the latter will allow hte user to store any new login credential they provide.
 
 Please note that if you're using SmartLock, you need to handle user logouts. To do this, either set up the `SmartlockReceiver` (as seen below) to listen for logout events or manually call `Credentials.getClient(activity, CredentialsOptions.DEFAULT).disableAutoSignIn()`.
 

--- a/ui/src/main/java/com/schibsted/account/ui/login/BaseLoginActivity.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/login/BaseLoginActivity.kt
@@ -194,7 +194,7 @@ abstract class BaseLoginActivity : AppCompatActivity(), KeyboardManager, Navigat
         if (SmartlockImpl.isSmartlockAvailable() && uiConfiguration.smartlockMode != SmartlockMode.DISABLED) {
             loginController = LoginController(true, params.scopes)
             smartlock = SmartlockImpl(this, loginController!!, loginContract)
-            if (isSmartlockRunning) {
+            if (isSmartlockRunning || uiConfiguration.smartlockMode == SmartlockMode.FAILED) {
                 progressBar.visibility = GONE
             } else {
                 progressBar.visibility = VISIBLE

--- a/ui/src/main/java/com/schibsted/account/ui/smartlock/SmartlockMode.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/smartlock/SmartlockMode.kt
@@ -3,5 +3,6 @@ package com.schibsted.account.ui.smartlock
 enum class SmartlockMode {
     DISABLED,
     ENABLED,
-    FORCED
+    FORCED,
+    FAILED
 }


### PR DESCRIPTION
This enables the users to store credentials even after they cancel the first request to choose credentials.

Fixes #236