### PR TITLE
Fix issue where redirect_uri was not correctly built

### DIFF
--- a/example/src/main/res/values/strings.xml
+++ b/example/src/main/res/values/strings.xml
@@ -13,5 +13,5 @@
     <string name="example_app_loading_info">Loading info…</string>
 
     <string name="schacc_conf_client_name">This is my client name</string>
-    <string name="schacc_conf_redirect_host">login</string>
+    <string name="schacc_conf_redirect_host">:/login</string>
 </resources>

--- a/example/src/main/res/values/strings.xml
+++ b/example/src/main/res/values/strings.xml
@@ -13,5 +13,5 @@
     <string name="example_app_loading_info">Loading info…</string>
 
     <string name="schacc_conf_client_name">This is my client name</string>
-    <string name="schacc_conf_redirect_host">:/login</string>
+    <string name="schacc_conf_redirect_host">://login</string>
 </resources>

--- a/ui/README.md
+++ b/ui/README.md
@@ -14,11 +14,14 @@ __Note:__ You should familiarize yourself with the [Core SDK Readme](../core) wh
 ## Configuration
 The minimal configuration of the SDK UIs are: client name, redirect scheme and redirect host. The client name is displayed on the terms and conditions screen as "I accept the terms and conditions for SPID and _yourAppName_", while the two other fields are required for deep linking and can be found in SelfService.
 
+You can find the redirect scheme and redirect host on self service with the following format `MyschemeMyhost` where `Myscheme` is everything before `:`, for example
+with `spid-myclientid://login` the scheme is `spid-myclientid` and the host is `://login`
+
 `strings.xml`
 ```xml
 <string name="schacc_conf_client_name">My client name</string>
 <string name="schacc_conf_redirect_scheme">spid-myclientid</string>
-<string name="schacc_conf_redirect_host">login</string>
+<string name="schacc_conf_redirect_host">://login</string>
 ``` 
 
 

--- a/ui/README.md
+++ b/ui/README.md
@@ -14,8 +14,8 @@ __Note:__ You should familiarize yourself with the [Core SDK Readme](../core) wh
 ## Configuration
 The minimal configuration of the SDK UIs are: client name, redirect scheme and redirect host. The client name is displayed on the terms and conditions screen as "I accept the terms and conditions for SPID and _yourAppName_", while the two other fields are required for deep linking and can be found in SelfService.
 
-You can find the redirect scheme and redirect host on self service with the following format `MyschemeMyhost` where `Myscheme` is everything before `:`, for example
-with `spid-myclientid://login` the scheme is `spid-myclientid` and the host is `://login`
+You can find the redirect scheme and redirect host on self service with the following format `MyschemeMyhost` where `Myscheme` is everything before `:`.
+For example with `spid-myclientid://login` the scheme is `spid-myclientid` and the host is `://login`
 
 `strings.xml`
 ```xml

--- a/ui/src/main/java/com/schibsted/account/ui/RequiredConfiguration.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/RequiredConfiguration.kt
@@ -2,6 +2,7 @@ package com.schibsted.account.ui
 
 import android.content.Context
 import android.os.Parcelable
+import com.schibsted.account.common.util.Logger
 import kotlinx.android.parcel.Parcelize
 import java.net.URI
 
@@ -13,12 +14,16 @@ data class RequiredConfiguration(val redirectUri: URI, val clientName: String) :
         fun fromResources(applicationContext: Context): RequiredConfiguration {
             val clientName = applicationContext.getString(R.string.schacc_conf_client_name)
             val redirectScheme = applicationContext.getString(R.string.schacc_conf_redirect_scheme)
-            val redirectHost = applicationContext.getString(R.string.schacc_conf_redirect_host)
+            var redirectHost = applicationContext.getString(R.string.schacc_conf_redirect_host)
 
             if (clientName.isNullOrBlank()) throw IllegalArgumentException("A value for the string <schacc_conf_client_name> must be provided in strings.xml")
             if (redirectScheme.isNullOrBlank()) throw IllegalArgumentException("A value for the string <schacc_conf_redirect_scheme> must be provided in strings.xml")
             if (redirectHost.isNullOrBlank()) throw IllegalArgumentException("A value for the string <schacc_conf_redirect_host> must be provided in strings.xml")
 
+            if (!redirectHost.contains(":/")) {
+                Logger.warn(Logger.DEFAULT_TAG + "-RequiredConfiguration", "Your host is not correct, deep links might fail, please provide a complete host")
+                redirectHost = "://$redirectHost"
+            }
             return RequiredConfiguration(URI.create("$redirectScheme$redirectHost"), clientName!!)
         }
     }

--- a/ui/src/main/java/com/schibsted/account/ui/RequiredConfiguration.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/RequiredConfiguration.kt
@@ -19,7 +19,7 @@ data class RequiredConfiguration(val redirectUri: URI, val clientName: String) :
             if (redirectScheme.isNullOrBlank()) throw IllegalArgumentException("A value for the string <schacc_conf_redirect_scheme> must be provided in strings.xml")
             if (redirectHost.isNullOrBlank()) throw IllegalArgumentException("A value for the string <schacc_conf_redirect_host> must be provided in strings.xml")
 
-            return RequiredConfiguration(URI.create("$redirectScheme://$redirectHost"), clientName!!)
+            return RequiredConfiguration(URI.create("$redirectScheme$redirectHost"), clientName!!)
         }
     }
 }

--- a/ui/src/main/java/com/schibsted/account/ui/RequiredConfiguration.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/RequiredConfiguration.kt
@@ -14,16 +14,19 @@ data class RequiredConfiguration(val redirectUri: URI, val clientName: String) :
         fun fromResources(applicationContext: Context): RequiredConfiguration {
             val clientName = applicationContext.getString(R.string.schacc_conf_client_name)
             val redirectScheme = applicationContext.getString(R.string.schacc_conf_redirect_scheme)
-            var redirectHost = applicationContext.getString(R.string.schacc_conf_redirect_host)
+            val redirectHost = applicationContext.getString(R.string.schacc_conf_redirect_host).let {
+                if (it.contains(":/")) {
+                    it
+                } else {
+                    Logger.warn(Logger.DEFAULT_TAG + "-RequiredConfiguration", "Your host is not correct, deep links might fail, please provide a complete host")
+                    "://$it"
+                }
+            }
 
             if (clientName.isNullOrBlank()) throw IllegalArgumentException("A value for the string <schacc_conf_client_name> must be provided in strings.xml")
             if (redirectScheme.isNullOrBlank()) throw IllegalArgumentException("A value for the string <schacc_conf_redirect_scheme> must be provided in strings.xml")
             if (redirectHost.isNullOrBlank()) throw IllegalArgumentException("A value for the string <schacc_conf_redirect_host> must be provided in strings.xml")
 
-            if (!redirectHost.contains(":/")) {
-                Logger.warn(Logger.DEFAULT_TAG + "-RequiredConfiguration", "Your host is not correct, deep links might fail, please provide a complete host")
-                redirectHost = "://$redirectHost"
-            }
             return RequiredConfiguration(URI.create("$redirectScheme$redirectHost"), clientName!!)
         }
     }


### PR DESCRIPTION
Fixes #306 
Now we don't automatically put `://` to build the redirect URI but we take what's given by the client.
Because `://` was something static in the code whatever we could do to fix the issue would result in a change from the client.
I have chosen the easiest solution for us and the client by just asking the client to add whether `://` or `:/` to their host. Of course, I was first thinking of "why split this value? let's just ask the client to give us the full self-service redirect URI". Unfortunately, we can't do that because we need the scheme to be added in the *static* AndroidManifest, so we can't resolve the scheme from the full self-service URI and inject it in the `android:scheme` field. I also thought of doing `android:scheme="*"` and do a comparison between the link we caught and the redirect URI given by the client but `android:scheme="*"`  is not allowed (and it makes sense).
