### PR TITLE
Add subscription endpoint

### DIFF
--- a/core/src/main/java/com/schibsted/account/network/response/SubscriptionsResponse.kt
+++ b/core/src/main/java/com/schibsted/account/network/response/SubscriptionsResponse.kt
@@ -1,0 +1,38 @@
+package com.schibsted.account.network.response
+
+import java.util.Date
+
+data class SubscriptionsResponse(val subscriptions: List<Subscription>)
+data class Subscription(
+    val subscriptionId: String,
+    val originalSubscriptionId: String,
+    val clientId: String,
+    val userId: String,
+    val productId: String,
+    val parentProductId: String,
+    val identifierId: String?,
+    val paymentType: String,
+    val orderId: String?,
+    val startDate: String,
+    val originalPurchaseDate: Date,
+    val expires: Date,
+    val autoRenew: String,
+    val autoRenewChangeDate: Date,
+    val autoRenewChangeBy: String?,
+    val renewPrice: String?,
+    val currency: String,
+    val renewPeriod: String,
+    val autoRenewLockPeriod: String,
+    val stopRenewalAfterLock: String,
+    val autoRenewDisabled: String,
+    val gracePeriod: String,
+    val emailReceiptCount: String,
+    val finalEndDate: Date,
+    val chargeRetryCount: String,
+    val chargeLastRetry: String?,
+    val status: String,
+    val statusChangeCode: String?,
+    val statusChangeDate: String?,
+    val updated: Date,
+    val created: Date
+)

--- a/core/src/main/java/com/schibsted/account/network/service/BaseNetworkService.java
+++ b/core/src/main/java/com/schibsted/account/network/service/BaseNetworkService.java
@@ -13,6 +13,7 @@ import com.google.gson.GsonBuilder;
 import com.schibsted.account.network.Environment;
 import com.schibsted.account.util.LenientAccountsDeserializer;
 import com.schibsted.account.util.Preconditions;
+import com.schibsted.account.util.SubscriptionDeserializer;
 import com.schibsted.account.util.TypeSafeStringDeserializer;
 
 import okhttp3.OkHttpClient;
@@ -52,6 +53,7 @@ public class BaseNetworkService {
         Preconditions.checkNotNull(service);
         final Gson gson = new GsonBuilder().setDateFormat("yyyy-MM-dd")
                 .registerTypeAdapter(LenientAccountsDeserializer.type, new LenientAccountsDeserializer())
+                .registerTypeAdapter(SubscriptionDeserializer.type, new SubscriptionDeserializer())
                 .registerTypeAdapter(String.class, new TypeSafeStringDeserializer())
                 .create();
         return new Retrofit.Builder()

--- a/core/src/main/java/com/schibsted/account/network/service/user/UserContract.kt
+++ b/core/src/main/java/com/schibsted/account/network/service/user/UserContract.kt
@@ -9,6 +9,7 @@ import com.schibsted.account.network.response.AgreementsResponse
 import com.schibsted.account.network.response.ApiContainer
 import com.schibsted.account.network.response.ProfileData
 import com.schibsted.account.network.response.RequiredFieldsResponse
+import com.schibsted.account.network.response.SubscriptionsResponse
 import retrofit2.Call
 import retrofit2.http.FieldMap
 import retrofit2.http.FormUrlEncoded
@@ -40,6 +41,9 @@ internal interface UserContract {
 
     @GET("api/2/user/{userId}")
     fun getUserProfile(@Header(KEY_AUTHORIZATION) userBearer: String, @Path(KEY_USER_ID) userId: String): Call<ApiContainer<ProfileData>>
+
+    @GET("api/2/subscriptions")
+    fun subscriptions(@Header(KEY_AUTHORIZATION) userBearer: String): Call<SubscriptionsResponse>
 
     companion object {
         const val KEY_AUTHORIZATION = "Authorization"

--- a/core/src/main/java/com/schibsted/account/network/service/user/UserService.kt
+++ b/core/src/main/java/com/schibsted/account/network/service/user/UserService.kt
@@ -9,6 +9,7 @@ import com.schibsted.account.network.response.AgreementsResponse
 import com.schibsted.account.network.response.ApiContainer
 import com.schibsted.account.network.response.ProfileData
 import com.schibsted.account.network.response.RequiredFieldsResponse
+import com.schibsted.account.network.response.SubscriptionsResponse
 import com.schibsted.account.network.response.TokenResponse
 import com.schibsted.account.network.service.BaseNetworkService
 import okhttp3.OkHttpClient
@@ -31,6 +32,10 @@ class UserService(environment: String, okHttpClient: OkHttpClient) : BaseNetwork
 
     fun getMissingRequiredFields(userId: String, userToken: TokenResponse): Call<ApiContainer<RequiredFieldsResponse>> {
         return this.userContract.requiredFields(userToken.bearerAuthHeader(), userId)
+    }
+
+    fun getSubscriptions(userToken: TokenResponse): Call<SubscriptionsResponse> {
+        return this.userContract.subscriptions(userToken.bearerAuthHeader())
     }
 
     /**

--- a/core/src/main/java/com/schibsted/account/session/Profile.kt
+++ b/core/src/main/java/com/schibsted/account/session/Profile.kt
@@ -10,6 +10,7 @@ import com.schibsted.account.model.NoValue
 import com.schibsted.account.model.error.ClientError
 import com.schibsted.account.network.NetworkCallback
 import com.schibsted.account.network.response.ProfileData
+import com.schibsted.account.network.response.Subscription
 import com.schibsted.account.network.service.user.UserService
 
 class Profile(val user: User, private val userService: UserService = UserService(ClientConfiguration.get().environment, user.authClient)) {
@@ -51,5 +52,18 @@ class Profile(val user: User, private val userService: UserService = UserService
                 { callback.onError(it.toClientError()) },
                 { callback.onSuccess(it.data.fields) })
         )
+    }
+
+    fun getSubscriptions(callback: ResultCallback<List<Subscription>>) {
+        val token = user.token
+        if (token == null) {
+            callback.onError(ClientError.USER_LOGGED_OUT_ERROR)
+            return
+        }
+        userService.getSubscriptions(token).enqueue(NetworkCallback.lambda("Fetching user subscriptions",
+                { callback.onError(it.toClientError()) },
+                {
+                    callback.onSuccess(it.subscriptions)
+                }))
     }
 }

--- a/core/src/main/java/com/schibsted/account/util/SubscriptionDeserializer.kt
+++ b/core/src/main/java/com/schibsted/account/util/SubscriptionDeserializer.kt
@@ -1,0 +1,28 @@
+package com.schibsted.account.util
+
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonDeserializationContext
+import com.google.gson.JsonDeserializer
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import com.google.gson.reflect.TypeToken
+import com.schibsted.account.network.response.Subscription
+import com.schibsted.account.network.response.SubscriptionsResponse
+import java.lang.reflect.Type
+
+class SubscriptionDeserializer : JsonDeserializer<SubscriptionsResponse> {
+    override fun deserialize(json: JsonElement?, typeOfT: Type?, context: JsonDeserializationContext?): SubscriptionsResponse {
+        val gson = GsonBuilder().setDateFormat("yyyy-MM-dd HH:mm:ss").create()
+        val data = (json as JsonObject).get("data") as JsonObject
+        val subscriptions = mutableListOf<Subscription>()
+        for (item in data.entrySet()) {
+            subscriptions.add(gson.fromJson<Subscription>(item.value, Subscription::class.java))
+        }
+        return SubscriptionsResponse(subscriptions)
+    }
+
+    companion object {
+        @JvmField
+        val type: Type = object : TypeToken<SubscriptionsResponse>() {}.type
+    }
+}


### PR DESCRIPTION
Fixes #272 
I wrapped the list of `Subscription`  into `SubscriptionResponse` because registering a TypeAdapter of Type `TypeToken<List<Subscription>>` wasn't working. It might be related to https://github.com/google/gson/issues/1274.

Also, I created a custom deserializer because the payload we receive contains objects with a dynamic name ( the object's name correspond to the subscription id...) so Gson can't automatically parse objects.
e.g. 
```
 "data": {
        "169252": {
            "subscriptionId": "169252",
             ...
        },
        "169253": {
            "subscriptionId": "169253",
            ...
        }
    }
```