### PR TITLE
Fix issue where contract could be evaluated twice

### DIFF
--- a/example/src/main/java/com/schibsted/account/example/MainActivity.java
+++ b/example/src/main/java/com/schibsted/account/example/MainActivity.java
@@ -113,7 +113,7 @@ public class MainActivity extends AppCompatActivity {
             button.setEnabled(false);
             button.setText(R.string.example_app_loading_info);
 
-            final Intent intent = AccountUi.getCallingIntent(getApplicationContext(), AccountUi.FlowType.PASSWORD,
+            final Intent intent = AccountUi.getCallingIntent(getApplicationContext(), AccountUi.FlowType.PASSWORDLESS_EMAIL,
                     new AccountUi.Params(getString(R.string.example_teaser_text), null, SmartlockMode.DISABLED, new String[]{OIDCScope.SCOPE_OPENID}));
             startActivityForResult(intent, PASSWORD_REQUEST_CODE);
         }

--- a/ui/src/main/java/com/schibsted/account/ui/login/flow/password/PasswordActivity.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/login/flow/password/PasswordActivity.kt
@@ -11,7 +11,6 @@ import com.schibsted.account.engine.controller.LoginController
 import com.schibsted.account.engine.controller.SignUpController
 import com.schibsted.account.engine.input.Identifier
 import com.schibsted.account.ui.login.BaseLoginActivity
-import com.schibsted.account.ui.login.screen.LoginScreen
 
 class PasswordActivity : BaseLoginActivity(), FlowSelectionListener {
 
@@ -72,16 +71,10 @@ class PasswordActivity : BaseLoginActivity(), FlowSelectionListener {
     override fun onBackPressed() {
         super.onBackPressed()
         if (isUserAvailable()) {
-            navigationController.handleBackPressed(signUpController)
+            navigationController.handleBackPressed(signUpController, signUpContract)
         } else {
-            navigationController.handleBackPressed(loginController)
+            navigationController.handleBackPressed(loginController, loginContract)
         }
-    }
-
-    override fun onNavigationDone(screen: LoginScreen) {
-        super.onNavigationDone(screen)
-        signUpController?.evaluate(signUpContract)
-        loginController?.evaluate(loginContract)
     }
 
     override fun onNavigateBackRequested() {

--- a/ui/src/main/java/com/schibsted/account/ui/login/flow/passwordless/PasswordlessActivity.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/login/flow/passwordless/PasswordlessActivity.kt
@@ -20,7 +20,6 @@ import com.schibsted.account.model.LoginResult
 import com.schibsted.account.model.error.ClientError
 import com.schibsted.account.network.response.AgreementLinksResponse
 import com.schibsted.account.ui.login.BaseLoginActivity
-import com.schibsted.account.ui.login.screen.LoginScreen
 import com.schibsted.account.ui.login.screen.identification.ui.MobileIdentificationFragment
 import com.schibsted.account.ui.navigation.Navigation
 import com.schibsted.account.ui.ui.FlowFragment
@@ -95,12 +94,7 @@ class PasswordlessActivity : BaseLoginActivity(), PasswordlessContract {
 
     override fun onBackPressed() {
         super.onBackPressed()
-        navigationController.handleBackPressed(passwordlessController)
-    }
-
-    override fun onNavigationDone(screen: LoginScreen) {
-        super.onNavigationDone(screen)
-        passwordlessController.evaluate(this)
+        navigationController.handleBackPressed(passwordlessController, this)
     }
 
     companion object {

--- a/ui/src/main/java/com/schibsted/account/ui/navigation/Navigation.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/navigation/Navigation.kt
@@ -132,12 +132,13 @@ class Navigation(
         })
     }
 
-    fun <T : Contract<*>, C : Controller<T>> handleBackPressed(controller: C?) {
+    fun <T : Contract<*>, C : Controller<T>> handleBackPressed(controller: C?, contract: T) {
         when (currentFragment?.tag) {
             LoginScreen.TC_SCREEN.value,
             LoginScreen.REQUIRED_FIELDS_SCREEN.value -> {
                 fragmentManager.popBackStack()
                 controller?.back()
+                controller?.evaluate(contract)
             }
 
             LoginScreen.CHECK_INBOX_SCREEN.value,
@@ -145,6 +146,7 @@ class Navigation(
             LoginScreen.VERIFICATION_SCREEN.value -> {
                 controller?.back(fragmentManager.backStackEntryCount)
                 fragmentManager.popBackStack(LoginScreen.IDENTIFICATION_SCREEN.value, 0)
+                controller?.evaluate(contract)
             }
 
             LoginScreen.WEB_TC_SCREEN.value,


### PR DESCRIPTION
See #310 , this PR solved the related bug but had a side effect of re-evaluating the contract twice in some cases. e.g. : When we first navigate to the identification screen.
This PR fixes this side effect.