### PR TITLE
Fix issue with behavior on rotation

### DIFF
--- a/ui/src/main/java/com/schibsted/account/ui/Event.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/Event.kt
@@ -1,0 +1,27 @@
+package com.schibsted.account.ui
+
+/**
+ * Used as a wrapper for data that is exposed via a LiveData that represents an event.
+ */
+open class Event<out T>(private val content: T) {
+
+    var hasBeenHandled = false
+        private set // Allow external read but not write
+
+    /**
+     * Returns the content and prevents its use again.
+     */
+    fun get(): T? {
+        return if (hasBeenHandled) {
+            null
+        } else {
+            hasBeenHandled = true
+            content
+        }
+    }
+
+    /**
+     * Returns the content, even if it's already been handled.
+     */
+    fun peek(): T = content
+}

--- a/ui/src/main/java/com/schibsted/account/ui/login/LoginActivityViewModel.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/login/LoginActivityViewModel.kt
@@ -108,7 +108,7 @@ class LoginActivityViewModel(
         if (intentClientInfo == null) {
             fetchClientInfo()
         } else {
-            clientResult.setValue(Event(ClientResult.Success(intentClientInfo)))
+            clientResult.value = Event(ClientResult.Success(intentClientInfo))
         }
     }
 
@@ -116,10 +116,10 @@ class LoginActivityViewModel(
         clientResolvingState.value = true
         ClientInfoOperation({ error ->
             clientResolvingState.value = false
-            clientResult.setValue(Event(ClientResult.Failure(error.toClientError())))
+            clientResult.value = Event(ClientResult.Failure(error.toClientError()))
         }, { info ->
             clientResolvingState.value = false
-            clientResult.setValue(Event(ClientResult.Success(info)))
+            clientResult.value = (Event(ClientResult.Success(info)))
         })
     }
 
@@ -137,9 +137,7 @@ class LoginActivityViewModel(
         }
     }
 
-    fun isFlowReady(): Boolean {
-        return smartlockCredentials.value == null && !smartlockReceiver.isSmartlockResolving.value && userFlowType != null
-    }
+    fun isFlowReady(): Boolean = smartlockCredentials.value == null && !smartlockReceiver.isSmartlockResolving.value && userFlowType != null
 
     sealed class ClientResult {
         data class Success(val clientInfo: ClientInfo) : ClientResult()

--- a/ui/src/main/java/com/schibsted/account/ui/login/flow/password/PasswordActivity.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/login/flow/password/PasswordActivity.kt
@@ -26,17 +26,14 @@ class PasswordActivity : BaseLoginActivity(), SignUpContract {
     private var signUpController: SignUpController? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
+
         super.onCreate(savedInstanceState)
-        viewModel.isFlowReady().observe(this, Observer { shouldFetchInfoFirst ->
-            shouldFetchInfoFirst?.let {
-                if (shouldFetchInfoFirst) {
-                    loadRequiredInformation()
-                } else {
-                    viewModel.startLoginController(this.loginContract)
-                    viewModel.startSignUpController(this)
-                }
-            }
-        })
+        if (viewModel.isFlowReady()) {
+            viewModel.startLoginController(this.loginContract)
+            viewModel.startSignUpController(this)
+        } else {
+            loadRequiredInformation()
+        }
 
         viewModel.smartlockCredentials.observe(this, Observer { credentials ->
             credentials?.let {


### PR DESCRIPTION
* Use Events Wrapper in order to have catch event only once with live data
* Do not initialize login controller when not needed.

Before this commit - 
* on device rotation user was redirected to the first screen because the ClientResult was emitted again (which cause a navigation to the first screen as intended).
* LoginController was created no matter what, and then the signup flow wasn't working (because handled by the login controller implementation, that means when you were trying to create an account under the hood the app was trying to log you in, and then you got an error saying "Sorry bro, credentials of yours are wrong".
