### PR TITLE
Do not rely on the App object to get the ui conf

### DIFF
--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -20,7 +20,7 @@
 
         <meta-data android:name="@string/schacc_conf_locale" android:value="nb_NO" />
         <meta-data android:name="@string/schacc_conf_cancellable" android:value="false" />
-        <meta-data android:name="@string/schacc_conf_client_logo" android:resource="@drawable/schacc_ic_cancel" />
+        <meta-data android:name="@string/schacc_conf_client_logo" android:resource="@drawable/ic_example_logo" />
 
         <activity android:name="com.schibsted.account.example.MainActivity">
             <intent-filter>

--- a/example/src/main/java/com/schibsted/account/example/MainActivity.java
+++ b/example/src/main/java/com/schibsted/account/example/MainActivity.java
@@ -20,19 +20,15 @@ import android.widget.Toast;
 
 import com.schibsted.account.AccountService;
 import com.schibsted.account.Events;
-import com.schibsted.account.common.util.Logger;
 import com.schibsted.account.engine.integration.ResultCallback;
 import com.schibsted.account.model.error.ClientError;
-import com.schibsted.account.network.OIDCScope;
 import com.schibsted.account.network.response.ProfileData;
-import com.schibsted.account.network.response.Subscription;
 import com.schibsted.account.session.User;
 import com.schibsted.account.smartlock.SmartlockReceiver;
 import com.schibsted.account.ui.AccountUi;
 import com.schibsted.account.ui.login.BaseLoginActivity;
 import com.schibsted.account.ui.smartlock.SmartlockMode;
 
-import java.util.List;
 import java.util.Locale;
 
 public class MainActivity extends AppCompatActivity {
@@ -114,7 +110,9 @@ public class MainActivity extends AppCompatActivity {
             button.setText(R.string.example_app_loading_info);
 
             final Intent intent = AccountUi.getCallingIntent(getApplicationContext(), AccountUi.FlowType.PASSWORD,
-                    new AccountUi.Params(getString(R.string.example_teaser_text), null, SmartlockMode.DISABLED, new String[]{OIDCScope.SCOPE_OPENID}));
+                    new AccountUi.Params.Builder()
+                            .teaserText(getString(R.string.example_teaser_text))
+                            .smartLockMode(SmartlockMode.DISABLED).build());
             startActivityForResult(intent, PASSWORD_REQUEST_CODE);
         }
     };
@@ -156,11 +154,9 @@ public class MainActivity extends AppCompatActivity {
                 case AccountUi.SMARTLOCK_FAILED:
                     // restart the flow, telling the SDK that SmartLock failed
                     final Intent intent = AccountUi.getCallingIntent(getApplicationContext(), AccountUi.FlowType.PASSWORD,
-                            new AccountUi.Params(
-                                    getString(R.string.example_teaser_text),
-                                    null,
-                                    SmartlockMode.FAILED,
-                                    new String[]{OIDCScope.SCOPE_OPENID}));
+                            new AccountUi.Params.Builder()
+                                    .teaserText(getString(R.string.example_teaser_text))
+                                    .smartLockMode(SmartlockMode.FAILED).build());
 
                     startActivityForResult(intent, PASSWORD_REQUEST_CODE);
                     break;

--- a/ui/README.md
+++ b/ui/README.md
@@ -26,7 +26,7 @@ For example with `spid-myclientid://login` the scheme is `spid-myclientid` and t
 
 
 ### Additional configuration parameters
-You can further control the behavior of the UIs bu specifying any of the following attributes. These can be specified in your `AndroidManifest.xml` or by implementing `OptionalConfiguration.UiConfigProvider` in your `Application` class. Using only one of these is recommended, but if you were to use both, then the configuration provider will be resolved before the manifest.
+You can further control the behavior of the UIs bu specifying any of the following attributes. These can be specified in your `AndroidManifest.xml` or by using `AccountUi.Params.Builder()`. Using only one of these is recommended, but if you were to use both, then the AccountUi parameters will take precedence over the manifest.
 
 - **Locale:** The locale to use for sending verification email and SMS from Schibsted Account in the following format `language_country` for example `nb_NO`. Defaults: `Locale.getDefault()`.
 - **Sign-up enabled:** Whether or not creation of new accounts should be allowed. Please note that an error message must be specified in order to disable this. Default: true.
@@ -45,18 +45,12 @@ You can further control the behavior of the UIs bu specifying any of the followi
 </application>
 ```
 
-#### Configuration provider
+#### AccountUi parameters
 ```java
-public class App extends Application implements OptionalConfiguration.UiConfigProvider {
-    @NonNull
-    @Override
-    public OptionalConfiguration getUiConfig() {
-        return new UiConfig.Builder()
-                .locale(new Locale("nb", "NO"))
-                .clientLogo(R.drawable.ic_example_logo)
-                .build();
-    }
-}
+ new AccountUi.Params.Builder()
+                               .teaserText(getString(R.string.example_teaser_text))
+                               ...
+                               .build());
 ```
 
 ### Starting the UIs

--- a/ui/src/main/java/com/schibsted/account/ui/AccountUi.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/AccountUi.kt
@@ -9,6 +9,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.os.Parcelable
+import android.support.annotation.DrawableRes
 import com.schibsted.account.engine.integration.ResultCallback
 import com.schibsted.account.engine.operation.ClientInfoOperation
 import com.schibsted.account.network.OIDCScope
@@ -18,6 +19,7 @@ import com.schibsted.account.ui.login.flow.passwordless.PasswordlessActivity
 import com.schibsted.account.ui.smartlock.SmartlockController
 import com.schibsted.account.ui.smartlock.SmartlockMode
 import kotlinx.android.parcel.Parcelize
+import java.util.Locale
 
 object AccountUi {
     const val KEY_PARAMS = "SCHACC_PARAMS"
@@ -42,11 +44,16 @@ object AccountUi {
      *
      */
     @Parcelize
-    data class Params(
+    data class Params internal constructor(
         val teaserText: String? = null,
         val preFilledIdentifier: String? = null,
         val smartLockMode: SmartlockMode = SmartlockMode.DISABLED,
+        val locale: Locale = Locale.getDefault(),
+        val signUpMode: SignUpMode = SignUpMode.Enabled,
+        val isCancellable: Boolean = true,
+        @DrawableRes val clientLogo: Int = 0,
         @OIDCScope val scopes: Array<String> = arrayOf(OIDCScope.SCOPE_OPENID)
+
     ) : Parcelable {
 
         class Builder {
@@ -55,6 +62,9 @@ object AccountUi {
             fun preFilledIdentifier(preFilledIdentifier: String?) = apply { params = params.copy(preFilledIdentifier = preFilledIdentifier) }
             fun smartLockMode(smartLockMode: SmartlockMode) = apply { params = params.copy(smartLockMode = smartLockMode) }
             fun scopes(@OIDCScope scopes: Array<String>) = apply { params = params.copy(scopes = scopes) }
+            fun locale(locale: Locale) = apply { params = params.copy(locale = locale) }
+            fun signUpMode(mode: SignUpMode) = apply { params = params.copy(signUpMode = mode) }
+            fun isCancellable(isCancellable: Boolean) = apply { params = params.copy(isCancellable = isCancellable) }
             fun build() = params
         }
 
@@ -81,12 +91,11 @@ object AccountUi {
         })
     }
 
+    /** @param context The application context
+     * @param flowType Which UI flow to initialize
+     * @param params Additional [Params] for the UIs
+     */
     @JvmStatic
-            /**
-             * @param context The application context
-             * @param flowType Which UI flow to initialize
-             * @param params Additional [Params] for the UIs
-             */
     fun getCallingIntent(context: Context, flowType: FlowType, params: Params = Params()): Intent {
         if (params.smartLockMode != SmartlockMode.DISABLED && !SmartlockController.isSmartlockAvailable()) {
             throw IllegalStateException("SmartLock is enabled, but not found on the classpath. Please verify that the smartlock module is included in your build")

--- a/ui/src/main/java/com/schibsted/account/ui/AccountUi.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/AccountUi.kt
@@ -41,19 +41,24 @@ object AccountUi {
     /**
      * @param teaserText A teaser text to show on the initial screen
      * @param preFilledIdentifier If the user ID is known, the identifier can be pre-filled
+     * @param smartLockMode A mode used to allow or not the user to log in using smartlock
+     * @param locale the locale to use in the UI
+     * @param signUpMode A mode used to allow or not the user to sign-up using the UI
+     * @param clientLogo a logo to display on the first screen
+     * @param scopes scopes to send along with a network request
      *
+     * Setting one of this value will take precedence over the one you could have defined in the manifest
      */
     @Parcelize
-    data class Params internal constructor(
-        val teaserText: String? = null,
-        val preFilledIdentifier: String? = null,
-        val smartLockMode: SmartlockMode = SmartlockMode.DISABLED,
-        val locale: Locale = Locale.getDefault(),
-        val signUpMode: SignUpMode = SignUpMode.Enabled,
-        val isCancellable: Boolean = true,
-        @DrawableRes val clientLogo: Int = 0,
-        @OIDCScope val scopes: Array<String> = arrayOf(OIDCScope.SCOPE_OPENID)
-
+    data class Params constructor(
+        val teaserText: String? = DEFAULT_TEASER,
+        val preFilledIdentifier: String? = DEFAULT_PREFILLED_IDENTIFIER,
+        val smartLockMode: SmartlockMode = DEFAULT_SMARTLOCK_MODE,
+        val locale: Locale? = null,
+        val signUpMode: SignUpMode = DEFAULT_SIGNUP_MODE,
+        val isCancellable: Boolean = DEFAULT_IS_CANCELLABLE,
+        @DrawableRes val clientLogo: Int = DEFAULT_CLIENT_LOGO,
+        @OIDCScope val scopes: Array<String> = DEFAULT_SCOPES
     ) : Parcelable {
 
         class Builder {
@@ -73,6 +78,16 @@ object AccountUi {
                 // when app is launched via deeplink the parcelable value is null
                 return bundle.getParcelable(KEY_PARAMS) as? Params ?: Params()
             }
+
+            internal val DEFAULT_TEASER: String? = null
+            internal val DEFAULT_PREFILLED_IDENTIFIER: String? = null
+            internal val DEFAULT_SMARTLOCK_MODE = SmartlockMode.DISABLED
+            internal val DEFAULT_LOCALE = Locale.getDefault()
+            internal val DEFAULT_SIGNUP_MODE = SignUpMode.Enabled
+            internal const val DEFAULT_IS_CANCELLABLE = true
+            internal val DEFAULT_SCOPES = arrayOf(OIDCScope.SCOPE_OPENID)
+            @DrawableRes
+            internal val DEFAULT_CLIENT_LOGO = 0
         }
     }
 

--- a/ui/src/main/java/com/schibsted/account/ui/InternalUiConfiguration.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/InternalUiConfiguration.kt
@@ -79,7 +79,7 @@ data class InternalUiConfiguration(
 
             val locale = when {
                 uiParams.locale != null -> uiParams.locale
-                else -> optionalConfig.locale ?: uiParams.locale ?: AccountUi.Params.DEFAULT_LOCALE
+                else -> optionalConfig.locale ?: AccountUi.Params.DEFAULT_LOCALE
             }
 
             val clientLogo = when {

--- a/ui/src/main/java/com/schibsted/account/ui/SignUpMode.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/SignUpMode.kt
@@ -1,0 +1,12 @@
+package com.schibsted.account.ui
+
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
+
+sealed class SignUpMode : Parcelable {
+    @Parcelize
+    object Enabled : SignUpMode()
+
+    @Parcelize
+    class Disabled(val disabledMessage: String) : SignUpMode()
+}

--- a/ui/src/main/java/com/schibsted/account/ui/ui/FlowFragment.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/ui/FlowFragment.kt
@@ -8,6 +8,8 @@ import android.os.Bundle
 import android.support.v4.app.Fragment
 import android.view.View
 import android.widget.Button
+import com.schibsted.account.engine.input.Identifier
+import com.schibsted.account.ui.AccountUi
 import com.schibsted.account.ui.InternalUiConfiguration
 import com.schibsted.account.ui.login.KeyboardVisibilityListener
 import com.schibsted.account.ui.ui.component.LoadingButton
@@ -31,7 +33,7 @@ abstract class FlowFragment<in T> : BaseFragment(), KeyboardVisibilityListener, 
 
         val args = requireNotNull(savedInstanceState ?: arguments)
 
-        this.uiConf = args.getParcelable(KEY_UI_CONF) ?: InternalUiConfiguration.resolve(activity!!.application)
+        this.uiConf = args.getParcelable(KEY_UI_CONF) ?: InternalUiConfiguration.resolve(activity!!.application, AccountUi.Params(), Identifier.IdentifierType.EMAIL)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/ui/src/test/java/com/schibsted/account/ui/UiConfigTest.kt
+++ b/ui/src/test/java/com/schibsted/account/ui/UiConfigTest.kt
@@ -11,31 +11,12 @@ import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import io.kotlintest.matchers.beOfType
-import io.kotlintest.matchers.should
+import io.kotlintest.should
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.WordSpec
 import java.util.Locale
 
 class UiConfigTest : WordSpec({
-    "Creating a new builder" should {
-        "retain the original values" {
-            val original = OptionalConfiguration(
-                    Locale.CANADA,
-                    OptionalConfiguration.SignUpMode.Disabled("Some message"),
-                    false,
-                    123)
-
-            original shouldBe original.newBuilder().build()
-        }
-    }
-
-    "The builder" should {
-        "correctly set values from the builder" {
-            val conf = OptionalConfiguration.Builder().locale(Locale.CHINA).clientLogo(123).build()
-            conf.locale shouldBe Locale.CHINA
-            conf.clientLogo shouldBe 123
-        }
-    }
 
     "fromManifest" should {
         "resolve it's fields from the manifest" {
@@ -62,21 +43,10 @@ class UiConfigTest : WordSpec({
             val conf = OptionalConfiguration.fromManifest(mockContext)
 
             conf.locale shouldBe locale
-            conf.signUpEnabled should beOfType<OptionalConfiguration.SignUpMode.Disabled>()
-            (conf.signUpEnabled as OptionalConfiguration.SignUpMode.Disabled).disabledMessage shouldBe "my disabled message"
+            conf.signUpMode should beOfType<SignUpMode.Disabled>()
+            (conf.signUpMode as SignUpMode.Disabled).disabledMessage shouldBe "my disabled message"
             conf.isCancellable shouldBe true
             conf.clientLogo shouldBe 555
-        }
-    }
-
-    "fromUiProvider" should {
-        "get it's properties from the provider" {
-            val provider = object : OptionalConfiguration.UiConfigProvider {
-                override fun getUiConfig() = OptionalConfiguration.DEFAULT.copy(Locale.GERMAN)
-            }
-
-            val result = OptionalConfiguration.fromUiProvider(provider)
-            result.locale shouldBe Locale.GERMAN
         }
     }
 })

--- a/ui/src/test/java/com/schibsted/account/ui/login/LoginActivityViewModelTest.kt
+++ b/ui/src/test/java/com/schibsted/account/ui/login/LoginActivityViewModelTest.kt
@@ -108,7 +108,7 @@ class LoginActivityViewModelTest : WordSpec({
             val clientInfo = ClientInfo("1", "client", "alias", mapOf(), "domain", 3, mapOf(), mapOf(), mock())
             loginActivityViewModel.getClientInfo(clientInfo)
             loginActivityViewModel.clientResult.value shouldBe instanceOf(LoginActivityViewModel.ClientResult.Success::class)
-            (loginActivityViewModel.clientResult.value as LoginActivityViewModel.ClientResult.Success).clientInfo shouldBe clientInfo
+            (loginActivityViewModel.clientResult.value?.peek() as LoginActivityViewModel.ClientResult.Success).clientInfo shouldBe clientInfo
         }
     }
 })


### PR DESCRIPTION
Fixes #329 
***What was the problem***
The locale was always retrieved from the manifest even if overridden programmatically. That was due to the call of `OptionalConfiguration.fromManifest` instead of `OptionalConfiguration.revolve`. The last method would apply the configuration correctly but unfortunately we can call it when we need it: We need it in `attachBaseContext` but this `resolve`  method needs an `Application` object which is not created yet.
***What are the changes***
*  The `Application` object is not required any longer to resolve the optional configurations
*  All optional configurations are now defined in one place cf. `AccountUi`
*  The sdk first tries to resolve the locale from the manifest and then tries to resolve it from the runtime conf