### PR TITLE
Fix issue where subscription endoint was crashing

### DIFF
--- a/core/src/main/java/com/schibsted/account/util/SubscriptionDeserializer.kt
+++ b/core/src/main/java/com/schibsted/account/util/SubscriptionDeserializer.kt
@@ -13,10 +13,13 @@ import java.lang.reflect.Type
 class SubscriptionDeserializer : JsonDeserializer<SubscriptionsResponse> {
     override fun deserialize(json: JsonElement?, typeOfT: Type?, context: JsonDeserializationContext?): SubscriptionsResponse {
         val gson = GsonBuilder().setDateFormat("yyyy-MM-dd HH:mm:ss").create()
-        val data = (json as JsonObject).get("data") as JsonObject
+        val data = (json as JsonObject).get("data") as? JsonObject
         val subscriptions = mutableListOf<Subscription>()
-        for (item in data.entrySet()) {
-            subscriptions.add(gson.fromJson<Subscription>(item.value, Subscription::class.java))
+
+        data?.let {
+            for (item in data.entrySet()) {
+                subscriptions.add(gson.fromJson<Subscription>(item.value, Subscription::class.java))
+            }
         }
         return SubscriptionsResponse(subscriptions)
     }


### PR DESCRIPTION
Fixes #334 
When the user has no subscription the `data` field returned by spid isn't a `JsonObject` but an empty `JsonArray`