### PR TITLE
Expose product subscription check

### DIFF
--- a/core/src/main/java/com/schibsted/account/network/response/ProductSubscription.kt
+++ b/core/src/main/java/com/schibsted/account/network/response/ProductSubscription.kt
@@ -1,0 +1,12 @@
+package com.schibsted.account.network.response
+
+data class ProductSubscription(
+    val name: String,
+    val code: Int,
+    val data: Data
+) {
+    data class Data(
+        val productId: String,
+        val result: Boolean
+    )
+}

--- a/core/src/main/java/com/schibsted/account/network/service/user/UserContract.kt
+++ b/core/src/main/java/com/schibsted/account/network/service/user/UserContract.kt
@@ -8,6 +8,7 @@ import com.schibsted.account.ListContainer
 import com.schibsted.account.network.response.AcceptAgreementResponse
 import com.schibsted.account.network.response.AgreementsResponse
 import com.schibsted.account.network.response.ApiContainer
+import com.schibsted.account.network.response.ProductSubscription
 import com.schibsted.account.network.response.ProfileData
 import com.schibsted.account.network.response.RequiredFieldsResponse
 import com.schibsted.account.network.response.Subscription
@@ -46,8 +47,12 @@ internal interface UserContract {
     @GET("api/2/user/{userId}/subscriptions")
     fun subscriptions(@Header(KEY_AUTHORIZATION) userBearer: String, @Path(KEY_USER_ID) userId: String): Call<ListContainer<Subscription>>
 
+    @GET("api/2/user/{userId}/product/{productId}")
+    fun getProductSubscription(@Header(KEY_AUTHORIZATION) userBearer: String, @Path(KEY_USER_ID) userId: String, @Path(KEY_PRODUCT_ID) productId: String): Call<ProductSubscription>
+
     companion object {
         const val KEY_AUTHORIZATION = "Authorization"
         const val KEY_USER_ID = "userId"
+        const val KEY_PRODUCT_ID = "productId"
     }
 }

--- a/core/src/main/java/com/schibsted/account/network/service/user/UserService.kt
+++ b/core/src/main/java/com/schibsted/account/network/service/user/UserService.kt
@@ -8,6 +8,7 @@ import com.schibsted.account.ListContainer
 import com.schibsted.account.network.response.AcceptAgreementResponse
 import com.schibsted.account.network.response.AgreementsResponse
 import com.schibsted.account.network.response.ApiContainer
+import com.schibsted.account.network.response.ProductSubscription
 import com.schibsted.account.network.response.ProfileData
 import com.schibsted.account.network.response.RequiredFieldsResponse
 import com.schibsted.account.network.response.Subscription
@@ -57,5 +58,16 @@ class UserService(environment: String, okHttpClient: OkHttpClient) : BaseNetwork
      */
     fun getUserProfile(userId: String, userToken: TokenResponse): Call<ApiContainer<ProfileData>> {
         return this.userContract.getUserProfile(userToken.serializedAccessToken, userId)
+    }
+
+    /**
+     * Retrieves subscription info on selected product
+     * @param userId The user's ID, must match the one in the token
+     * @param userToken The user's access token
+     * @param productId The product's ID to check (e.g. specific newspaper)
+     * @return On success it will return the [ProductSubscription], failure if something went wrong
+     */
+    fun getProductSubscription(userToken: TokenResponse, userId: String, productId: String): Call<ProductSubscription> {
+        return this.userContract.getProductSubscription(userToken.serializedAccessToken, userId, productId)
     }
 }

--- a/core/src/main/java/com/schibsted/account/session/Profile.kt
+++ b/core/src/main/java/com/schibsted/account/session/Profile.kt
@@ -9,6 +9,7 @@ import com.schibsted.account.engine.integration.ResultCallback
 import com.schibsted.account.model.NoValue
 import com.schibsted.account.model.error.ClientError
 import com.schibsted.account.network.NetworkCallback
+import com.schibsted.account.network.response.ProductSubscription
 import com.schibsted.account.network.response.ProfileData
 import com.schibsted.account.network.response.Subscription
 import com.schibsted.account.network.service.user.UserService
@@ -65,5 +66,21 @@ class Profile(val user: User, private val userService: UserService = UserService
                 {
                     callback.onSuccess(it.value)
                 }))
+    }
+
+    fun getProductSubscription(productId: String, callback: ResultCallback<ProductSubscription>) {
+        val token = user.token
+        if(token == null) {
+            callback.onError(ClientError.USER_LOGGED_OUT_ERROR)
+            return
+        }
+        userService.getProductSubscription(token, user.userId.id, productId).enqueue(NetworkCallback.lambda("Fetching product info",
+            {
+                callback.onError(it.toClientError())
+            },
+            {
+               callback.onSuccess(it)
+            }
+        ))
     }
 }


### PR DESCRIPTION
Fixed this issue: [358](https://github.com/schibsted/account-sdk-android/issues/358)

Adds a new endpoint for checking product subscription for specific user. [Docs](https://techdocs.spid.no/endpoints/GET/user/%7BuserId%7D/product/%7BproductId%7D/). Exposes it as a part of user profile. 