### PR TITLE
Fix info bar layout

### DIFF
--- a/ui/src/main/res/layout/schacc_password_fragment_layout.xml
+++ b/ui/src/main/res/layout/schacc_password_fragment_layout.xml
@@ -11,15 +11,16 @@
     <TextView
         android:id="@+id/info_bar_message"
         style="@style/schacc_infoBar"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="40dp"
         android:visibility="gone"
         android:drawableStart="@drawable/schacc_ic_info"
         android:drawableLeft="@drawable/schacc_ic_info"
         android:text="@string/schacc_password_sign_up_notification"
-        app:layout_constraintBottom_toTopOf="@id/schacc_constraintlayout"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        tools:visibility="visible"
         tools:layout_editor_absoluteX="0dp" />
 
     <android.support.constraint.ConstraintLayout
@@ -28,7 +29,7 @@
         android:layout_height="match_parent"
         app:layout_constraintTop_toBottomOf="@+id/info_bar_message"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent" >
+        app:layout_constraintLeft_toLeftOf="parent">
 
         <include layout="@layout/schacc_include_accessibility_fix" />
 
@@ -37,9 +38,13 @@
             android:paddingTop="8dp"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
             android:gravity="center"
             android:text="@string/schacc_age_limit_information"
-            android:visibility="gone" />
+            android:visibility="gone"
+            tools:visibility="visible" />
 
         <com.schibsted.account.ui.ui.component.AccountSelectorView
             android:id="@+id/account_selector_view"


### PR DESCRIPTION
This fixes issues with `info_bar_message` (`schacc_password_fragment_layout`) not displaying in apps using `ConstraintLayout` in version `1.1.3` (possibly lower)

## How to verify issue

On master:
- Update `ConstraintLayout` to `1.1.3`
- Run sample app and try to register new account
- `info_bar_message` doesn't show (`LayoutInspector` will verify that it's hidden under the `Toolbar`)

## How to fix

Apply this commit. It fixes some constraints between `info_bar_message` and `age_limit_info`. The second one didn't have them specified at all and while it worked on the older version of the library, in newer ones it doesn't (just how it should be).

This PR doesn't upgrade `ConstraintLayout` to newest version because it's out of scope. I couldn't verify that bumping the version doesn't bring any other issues in the rest of the project but I recommend doing that.

## Screenshots

Master with `1.1.3`:

![screenshot_1546860412](https://user-images.githubusercontent.com/37446534/50766137-6caa8200-1278-11e9-9870-077764d5ec88.png)

This PR:

![screenshot_1546859734](https://user-images.githubusercontent.com/37446534/50766147-7338f980-1278-11e9-81e0-ee44938537b7.png)

Hermes app after this PR:

![screenshot_1546859670](https://user-images.githubusercontent.com/37446534/50766155-78964400-1278-11e9-8f14-bae5743ed82b.png)