### PR TITLE
Always initiate SmartlockController if it's on the classpath.

### DIFF
--- a/ui/src/main/java/com/schibsted/account/ui/login/BaseLoginActivity.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/login/BaseLoginActivity.kt
@@ -138,6 +138,10 @@ abstract class BaseLoginActivity : AppCompatActivity(), NavigationListener {
 
         loginContract = LoginContractImpl(this, viewModel)
 
+        if (SmartlockController.isSmartlockAvailable()) {
+            smartlockController = SmartlockController(this, viewModel.smartlockReceiver)
+        }
+
         val action = DeepLinkHandler.resolveDeepLink(intent.dataString)
         if (action is DeepLink.ValidateAccount) {
             followDeepLink(intent.dataString, action, navigationController.currentFragment?.tag)
@@ -148,7 +152,6 @@ abstract class BaseLoginActivity : AppCompatActivity(), NavigationListener {
         viewModel.startSmartLockFlow.observe(this, Observer { launchSmartlock ->
             launchSmartlock?.let {
                 if (launchSmartlock) {
-                    smartlockController = SmartlockController(this, viewModel.smartlockReceiver)
                     smartlockController?.start()
                 }
             }


### PR DESCRIPTION
### Description
This ensures new credentials [can be saved](https://github.com/schibsted/account-sdk-android/blob/5b6b224/ui/src/main/java/com/schibsted/account/ui/login/screen/password/PasswordPresenter.kt#L33) when the user does not already
have their Schibsted account credentials stored.

### Testing instructions
1. Enable SmartLock in the example app: change to `SmartlockMode.ENABLED` [here](https://github.com/schibsted/account-sdk-android/blob/5b6b224/example/src/main/java/com/schibsted/account/example/MainActivity.java#L115).
2. Start the example app on a device with an added Google account
3. Click Login button
4. When prompted by Smart Lock to “Continue with”, select “None of the above”
5. Log in with username+password
6. Verify you’re prompted to store the credentials with your Google account and select “Save password”
7. Verify the credentials have been stored at https://passwords.google.com for `example.account.schibsted.com`
8. Verify you’re logged in
9. Click Logout button
10. Click Login button to log in again
11. Verify you’re prompted to use the newly stored credentials and select them to continue
12. Verify you’re logged in