### PR TITLE
Make the phone prefix input field show 'next' option in the keyboard.

### DIFF
--- a/ui/src/main/res/layout/schacc_phone_widget.xml
+++ b/ui/src/main/res/layout/schacc_phone_widget.xml
@@ -26,6 +26,7 @@
         android:layout_marginRight="0dp"
         android:layout_marginTop="4dp"
         android:inputType="phone"
+        android:imeOptions="actionNext"
         android:maxLength="4"
         app:layout_constraintEnd_toStartOf="@+id/guideline"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
### Testing instructions
1. Using passwordless SMS login (`AccountUi.FlowType.PASSWORDLESS_SMS`), click the phone number prefix input field.
1. Verify the next button is shown as below and that clicking it moves the cursor the phone number field.
![1_0j2Tbzl98h-FaUItYoRSdQ](https://user-images.githubusercontent.com/1183700/57309592-a5ece480-70e8-11e9-9978-ddde029569fa.jpeg) 
