### PR TITLE
Don't call /api/2/logout endpoint on user logout.

### DIFF
--- a/core/src/main/java/com/schibsted/account/network/service/user/UserContract.kt
+++ b/core/src/main/java/com/schibsted/account/network/service/user/UserContract.kt
@@ -26,9 +26,6 @@ import retrofit2.http.Path
  */
 internal interface UserContract {
 
-    @GET("api/2/logout")
-    fun logout(@Header(KEY_AUTHORIZATION) userBearer: String): Call<Unit>
-
     @POST("api/2/user/{userId}/agreements/accept")
     fun agreementAccept(@Header(KEY_AUTHORIZATION) userBearer: String, @Path(KEY_USER_ID) userId: String): Call<ApiContainer<AcceptAgreementResponse>>
 

--- a/core/src/main/java/com/schibsted/account/network/service/user/UserService.kt
+++ b/core/src/main/java/com/schibsted/account/network/service/user/UserService.kt
@@ -21,10 +21,6 @@ import retrofit2.Call
 class UserService(environment: String, okHttpClient: OkHttpClient) : BaseNetworkService(environment, okHttpClient) {
     private val userContract: UserContract = createService(UserContract::class.java)
 
-    fun logout(accessToken: TokenResponse): Call<Unit> {
-        return this.userContract.logout(accessToken.bearerAuthHeader())
-    }
-
     fun getUserAgreements(userId: String, userToken: TokenResponse): Call<ApiContainer<AgreementsResponse>> {
         return this.userContract.agreements(userToken.bearerAuthHeader(), userId)
     }

--- a/core/src/main/java/com/schibsted/account/session/User.kt
+++ b/core/src/main/java/com/schibsted/account/session/User.kt
@@ -67,16 +67,6 @@ class User(token: UserToken, val isPersistable: Boolean) : Parcelable {
         val token = this.token
         if (token != null) {
             AccountService.localBroadcastManager?.sendBroadcast(Intent(Events.ACTION_USER_LOGOUT).putExtra(Events.EXTRA_USER_ID, userId))
-            userService.logout(token).enqueue(NetworkCallback.lambda("Logging out user",
-                    {
-                        callback?.onError(it.toClientError())
-                        this@User.token = null
-                    },
-                    {
-                        callback?.onSuccess(NoValue)
-                        this@User.token = null
-                    })
-            )
         } else {
             callback?.onError(ClientError(ClientError.ErrorType.INVALID_STATE, "User already logged out"))
         }
@@ -144,7 +134,6 @@ class User(token: UserToken, val isPersistable: Boolean) : Parcelable {
             Logger.verbose("User token refreshing failed")
             if (listOf(400, 401, 403).contains(resp.code())) {
                 Logger.verbose("Logging out user")
-                userService.logout(token).execute()
                 this@User.token = null
 
                 AccountService.localBroadcastManager?.sendBroadcast(Intent(Events.ACTION_USER_LOGOUT).putExtra(Events.EXTRA_USER_ID, userId))


### PR DESCRIPTION
The endpoint currently does nothing and will be deprecated.