### PR TITLE
Expose Auth Interceptor outside

### DIFF
--- a/core/src/main/java/com/schibsted/account/network/AuthInterceptor.kt
+++ b/core/src/main/java/com/schibsted/account/network/AuthInterceptor.kt
@@ -45,7 +45,7 @@ internal fun protocolCheck(allowNonHttps: Boolean = false) = AuthCheck { req ->
  * @param allowNonHttps Whether or not non-https domains should be allowed. Defaults to false
  * @param timeout The timeout for token refreshing
  */
-class AuthInterceptor internal constructor(
+class AuthInterceptor constructor(
     private val user: User,
     private val urlWhitelist: List<String>,
     private val allowNonHttps: Boolean = false,


### PR DESCRIPTION
This lets consumers of the SDK to create interceptor on their own OkHttpClient instance instead of relying on `user.bind()` method.

Manual PR just for Travis sake
Original in #387.

