### PR TITLE
Fix for Retreiving stored user credentials fails 100% time on Huawei P20 device (see #388)

### DIFF
--- a/core/src/main/java/com/schibsted/account/persistence/EncryptionKeyProvider.kt
+++ b/core/src/main/java/com/schibsted/account/persistence/EncryptionKeyProvider.kt
@@ -137,7 +137,8 @@ class EncryptionKeyProvider(private val appContext: Context) {
                 GregorianCalendar(SimpleTimeZone(0, it))
             }
 
-            val startValid = (localizedTime ?: GregorianCalendar()).time
+            val startValid = (localizedTime
+                    ?: GregorianCalendar()).apply { add(Calendar.HOUR_OF_DAY, -26) }.time:
             val endValid = (localizedTime
                     ?: GregorianCalendar()).apply { add(Calendar.YEAR, 1) }.time
 

--- a/core/src/main/java/com/schibsted/account/persistence/EncryptionKeyProvider.kt
+++ b/core/src/main/java/com/schibsted/account/persistence/EncryptionKeyProvider.kt
@@ -138,7 +138,7 @@ class EncryptionKeyProvider(private val appContext: Context) {
             }
 
             val startValid = (localizedTime
-                    ?: GregorianCalendar()).apply { add(Calendar.HOUR_OF_DAY, -26) }.time
+                    ?: GregorianCalendar()).apply { add(Calendar.DAY_OF_YEAR, -1) }.time
             val endValid = (localizedTime
                     ?: GregorianCalendar()).apply { add(Calendar.YEAR, 1) }.time
 

--- a/core/src/main/java/com/schibsted/account/persistence/EncryptionKeyProvider.kt
+++ b/core/src/main/java/com/schibsted/account/persistence/EncryptionKeyProvider.kt
@@ -138,7 +138,7 @@ class EncryptionKeyProvider(private val appContext: Context) {
             }
 
             val startValid = (localizedTime
-                    ?: GregorianCalendar()).apply { add(Calendar.HOUR_OF_DAY, -26) }.time:
+                    ?: GregorianCalendar()).apply { add(Calendar.HOUR_OF_DAY, -26) }.time
             val endValid = (localizedTime
                     ?: GregorianCalendar()).apply { add(Calendar.YEAR, 1) }.time
 


### PR DESCRIPTION
Use a start date in the past for the encryption key to avoid timezone issue with huawei p20.
See this [thread](https://github.com/iamMehedi/Secured-Preference-Store/issues/15) for more details.

This should fix https://github.com/schibsted/account-sdk-android/issues/388