### PR TITLE
Bug fix: Add a bearer prefix to the Authorization header

### DIFF
--- a/core/src/main/java/com/schibsted/account/network/service/user/UserService.kt
+++ b/core/src/main/java/com/schibsted/account/network/service/user/UserService.kt
@@ -54,7 +54,7 @@ class UserService(environment: String, okHttpClient: OkHttpClient) : BaseNetwork
      * @return On success it will return the profile data, failure if something went wrong
      */
     fun getUserProfile(userId: String, userToken: TokenResponse): Call<ApiContainer<ProfileData>> {
-        return this.userContract.getUserProfile(userToken.serializedAccessToken, userId)
+        return this.userContract.getUserProfile(userToken.bearerAuthHeader(), userId)
     }
 
     /**
@@ -65,7 +65,7 @@ class UserService(environment: String, okHttpClient: OkHttpClient) : BaseNetwork
      * @return On success it will return if the user has access, failure if something went wrong or the user doesn't have access
      */
     fun getProductAccess(userToken: TokenResponse, userId: String, productId: String): Call<ApiContainer<ProductAccess>> {
-        return this.userContract.getProductAccess(userToken.serializedAccessToken, userId, productId)
+        return this.userContract.getProductAccess(userToken.bearerAuthHeader(), userId, productId)
     }
 
     /**

--- a/core/src/main/java/com/schibsted/account/persistence/EncryptionKeyProvider.kt
+++ b/core/src/main/java/com/schibsted/account/persistence/EncryptionKeyProvider.kt
@@ -137,7 +137,8 @@ class EncryptionKeyProvider(private val appContext: Context) {
                 GregorianCalendar(SimpleTimeZone(0, it))
             }
 
-            val startValid = (localizedTime ?: GregorianCalendar()).time
+            val startValid = (localizedTime
+                    ?: GregorianCalendar()).apply { add(Calendar.HOUR_OF_DAY, -26) }.time:
             val endValid = (localizedTime
                     ?: GregorianCalendar()).apply { add(Calendar.YEAR, 1) }.time
 

--- a/core/src/main/java/com/schibsted/account/persistence/EncryptionKeyProvider.kt
+++ b/core/src/main/java/com/schibsted/account/persistence/EncryptionKeyProvider.kt
@@ -138,7 +138,7 @@ class EncryptionKeyProvider(private val appContext: Context) {
             }
 
             val startValid = (localizedTime
-                    ?: GregorianCalendar()).apply { add(Calendar.HOUR_OF_DAY, -26) }.time:
+                    ?: GregorianCalendar()).apply { add(Calendar.HOUR_OF_DAY, -26) }.time
             val endValid = (localizedTime
                     ?: GregorianCalendar()).apply { add(Calendar.YEAR, 1) }.time
 


### PR DESCRIPTION
According to https://techdocs.login.schibsted.com the endpoints [api/2/user/{userId}](https://techdocs.login.schibsted.com/endpoints/GET/user/%7BuserId%7D/) and [api/2/user/{userId}/product/{productId}](https://techdocs.login.schibsted.com/endpoints/GET/user/%7BuserId%7D/product/%7BproductId%7D/) should have a Bearer access token. We currently don't have that prefix set, which cause the first requests to fail, and subsequently refresh the token before finally succeeding. 

