### PR TITLE
Added resetting of services to  ClientConfiguration set method.

### DIFF
--- a/core/src/main/java/com/schibsted/account/ClientConfiguration.kt
+++ b/core/src/main/java/com/schibsted/account/ClientConfiguration.kt
@@ -9,6 +9,7 @@ import android.os.Parcelable
 import android.support.annotation.VisibleForTesting
 import com.schibsted.account.common.util.Logger
 import com.schibsted.account.network.Environment
+import com.schibsted.account.network.ServiceHolder
 import com.schibsted.account.util.ConfigurationUtils
 
 /**
@@ -61,6 +62,8 @@ data class ClientConfiguration(
         @JvmStatic
         fun set(clientConfiguration: ClientConfiguration) {
             currentConfig = clientConfiguration
+
+            ServiceHolder.reset()
         }
 
         @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)

--- a/core/src/main/java/com/schibsted/account/network/ServiceHolder.kt
+++ b/core/src/main/java/com/schibsted/account/network/ServiceHolder.kt
@@ -25,4 +25,10 @@ object ServiceHolder {
     internal var clientService = ClientService(ClientConfiguration.get().environment, defaultClient)
 
     internal var passwordlessService = PasswordlessService(ClientConfiguration.get().environment, defaultClient)
+
+    internal fun reset() {
+        oAuthService = OAuthService(ClientConfiguration.get().environment, defaultClient)
+        clientService = ClientService(ClientConfiguration.get().environment, defaultClient)
+        passwordlessService = PasswordlessService(ClientConfiguration.get().environment, defaultClient)
+    }
 }


### PR DESCRIPTION
If applied, this commit will allow replacing environment in runtime using method "set".