### PR TITLE
Fix pre-lollipop vector drawables crash

### DIFF
--- a/ui/src/main/java/com/schibsted/account/ui/login/screen/password/PasswordFragment.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/login/screen/password/PasswordFragment.kt
@@ -57,6 +57,8 @@ class PasswordFragment : FlowFragment<PasswordContract.Presenter>(), PasswordCon
         super.onViewCreated(view, savedInstanceState)
         addUserOptions(isUserAvailable)
 
+        info_bar_message.setCompoundDrawablesWithIntrinsicBounds(R.drawable.schacc_ic_info, 0, 0, 0)
+
         mobile_password_button_forgot.setOnClickListener {
             BaseLoginActivity.tracker?.eventEngagement(TrackingData.Engagement.CLICK, TrackingData.UIElement.FORGOT_PASSWORD, TrackingData.Screen.PASSWORD)
 

--- a/ui/src/main/res/layout-land/schacc_password_fragment_layout.xml
+++ b/ui/src/main/res/layout-land/schacc_password_fragment_layout.xml
@@ -14,8 +14,6 @@
         android:layout_width="match_parent"
         android:visibility="gone"
         android:layout_height="40dp"
-        android:drawableStart="@drawable/schacc_ic_info"
-        android:drawableLeft="@drawable/schacc_ic_info"
         android:text="@string/schacc_password_sign_up_notification"
          />
 

--- a/ui/src/main/res/layout/schacc_password_fragment_layout.xml
+++ b/ui/src/main/res/layout/schacc_password_fragment_layout.xml
@@ -15,8 +15,6 @@
         android:layout_width="match_parent"
         android:layout_height="40dp"
         android:visibility="gone"
-        android:drawableStart="@drawable/schacc_ic_info"
-        android:drawableLeft="@drawable/schacc_ic_info"
         android:text="@string/schacc_password_sign_up_notification" />
 
     <android.support.constraint.ConstraintLayout


### PR DESCRIPTION
According to current appcompat libraries setup. Tested on API 19 and 28.

There are different approaches to solution:
https://stackoverflow.com/questions/36867298/using-android-vector-drawables-on-pre-lollipop-crash
https://stackoverflow.com/questions/34417843/how-to-use-vector-drawables-in-android-api-lower-21/40523623#40523623

But for our current compat libraries setup this is the one which works.