### PR TITLE
Added missing callback invocation on success.

### DIFF
--- a/core/src/main/java/com/schibsted/account/session/User.kt
+++ b/core/src/main/java/com/schibsted/account/session/User.kt
@@ -67,6 +67,7 @@ class User(token: UserToken, val isPersistable: Boolean) : Parcelable {
         val token = this.token
         if (token != null) {
             AccountService.localBroadcastManager?.sendBroadcast(Intent(Events.ACTION_USER_LOGOUT).putExtra(Events.EXTRA_USER_ID, userId))
+            callback?.onSuccess(NoValue)
         } else {
             callback?.onError(ClientError(ClientError.ErrorType.INVALID_STATE, "User already logged out"))
         }


### PR DESCRIPTION
If applied, this commit will fix the issue of using onSuccessFun with logout.

For now, it is a bit misleading that we can pass onSuccessFun to logout method but it will never be invoked.