### PR TITLE
Fix 393: Prefill identifier from SmartLock when no stored credentials.

### DIFF
--- a/ui/src/main/java/com/schibsted/account/ui/login/BaseLoginActivity.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/login/BaseLoginActivity.kt
@@ -131,7 +131,7 @@ abstract class BaseLoginActivity : AppCompatActivity(), NavigationListener {
         fragmentProvider = FragmentProvider(uiConfiguration, navigationController)
 
         val smartlockTask = SmartlockTask(params.smartLockMode)
-        viewModel = ViewModelProviders.of(this, LoginActivityViewModelFactory(smartlockTask, uiConfiguration.redirectUri, params)).get(LoginActivityViewModel::class.java)
+        viewModel = ViewModelProviders.of(this, LoginActivityViewModelFactory(smartlockTask, uiConfiguration, params)).get(LoginActivityViewModel::class.java)
 
         viewModel.smartlockCredentials.value = intent.getParcelableExtra(KEY_SMARTLOCK_CREDENTIALS)
         initializePropertiesFromBundle(savedInstanceState)
@@ -171,6 +171,9 @@ abstract class BaseLoginActivity : AppCompatActivity(), NavigationListener {
                     } else {
                         smartlockController?.provideHint(result.credentials)
                         fragmentProvider = FragmentProvider(uiConfiguration, navigationController)
+                        navigationController.currentFragment
+                                ?.let { it as? EmailIdentificationFragment }
+                                ?.prefillIdentifier(uiConfiguration.identifier)
                     }
                 }
                 is SmartlockTask.SmartLockResult.Failure -> {

--- a/ui/src/main/java/com/schibsted/account/ui/login/LoginActivityViewModel.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/login/LoginActivityViewModel.kt
@@ -32,9 +32,10 @@ import java.net.URI
 
 class LoginActivityViewModel(
     private val smartlockTask: SmartlockTask,
-    private val redirectUri: URI,
+    uiConfiguration: InternalUiConfiguration,
     private val params: AccountUi.Params
 ) : ViewModel(), FlowSelectionListener {
+    private val redirectUri = uiConfiguration.redirectUri
 
     val loginController = MutableLiveData<Event<LoginController>>()
     val signUpController = MutableLiveData<Event<SignUpController>>()
@@ -58,6 +59,7 @@ class LoginActivityViewModel(
         smartlockReceiver.isSmartlockResolving.addListener(false, true) {
             smartlockResolvingState.value = smartlockReceiver.isSmartlockResolving.value
         }
+        this.uiConfiguration.value = uiConfiguration
     }
 
     override fun onFlowSelected(flowType: FlowSelectionListener.FlowType, identifier: Identifier) {

--- a/ui/src/main/java/com/schibsted/account/ui/login/LoginActivityViewModelFactory.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/login/LoginActivityViewModelFactory.kt
@@ -8,7 +8,6 @@ import android.arch.lifecycle.ViewModelProvider
 import com.schibsted.account.ui.AccountUi
 import com.schibsted.account.ui.InternalUiConfiguration
 import com.schibsted.account.ui.smartlock.SmartlockTask
-import java.net.URI
 
 class LoginActivityViewModelFactory(
     private val smartlockTask: SmartlockTask,

--- a/ui/src/main/java/com/schibsted/account/ui/login/LoginActivityViewModelFactory.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/login/LoginActivityViewModelFactory.kt
@@ -6,19 +6,20 @@ package com.schibsted.account.ui.login
 import android.arch.lifecycle.ViewModel
 import android.arch.lifecycle.ViewModelProvider
 import com.schibsted.account.ui.AccountUi
+import com.schibsted.account.ui.InternalUiConfiguration
 import com.schibsted.account.ui.smartlock.SmartlockTask
 import java.net.URI
 
 class LoginActivityViewModelFactory(
     private val smartlockTask: SmartlockTask,
-    private val redirectUri: URI,
+    private val uiConfiguration: InternalUiConfiguration,
     private val params: AccountUi.Params
 ) : ViewModelProvider.Factory {
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         return modelClass.getConstructor(
                 smartlockTask::class.java,
-                redirectUri::class.java,
-                params::class.java).newInstance(smartlockTask, redirectUri, params)
+                uiConfiguration::class.java,
+                params::class.java).newInstance(smartlockTask, uiConfiguration, params)
     }
 }

--- a/ui/src/main/java/com/schibsted/account/ui/login/screen/identification/ui/EmailIdentificationFragment.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/login/screen/identification/ui/EmailIdentificationFragment.kt
@@ -50,7 +50,7 @@ class EmailIdentificationFragment : AbstractIdentificationFragment(), Identifica
             Logger.info(TAG, "email wasn't found")
         } else {
             if (EmailValidationRule.isValid(identifier)) {
-                inputFieldView.inputField.setText(uiConf.identifier)
+                inputFieldView.inputField.setText(identifier)
                 Logger.info(TAG, "email has been prefilled")
             } else {
                 Logger.warn(TAG, "Failed to prefill the email - Wrong format")

--- a/ui/src/main/java/com/schibsted/account/ui/login/screen/identification/ui/MobileIdentificationFragment.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/login/screen/identification/ui/MobileIdentificationFragment.kt
@@ -43,7 +43,7 @@ class MobileIdentificationFragment : AbstractIdentificationFragment() {
             Logger.info(TAG, "The phone number wasn't found")
         } else {
             if (TextUtils.isDigitsOnly(identifier)) {
-                inputFieldView.setPhoneNumber(uiConf.identifier!!)
+                inputFieldView.setPhoneNumber(identifier!!)
                 Logger.info(TAG, "The phone number has been prefilled")
             } else {
                 Logger.warn(TAG, "Failed to prefill the phone number - Wrong format")

--- a/ui/src/test/java/com/schibsted/account/ui/login/LoginActivityViewModelTest.kt
+++ b/ui/src/test/java/com/schibsted/account/ui/login/LoginActivityViewModelTest.kt
@@ -18,7 +18,6 @@ import io.kotlintest.matchers.instanceOf
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.WordSpec
 import org.mockito.internal.verification.Times
-import java.net.URI
 
 class LoginActivityViewModelTest : WordSpec({
 
@@ -36,7 +35,7 @@ class LoginActivityViewModelTest : WordSpec({
 
     val smartlockTask: SmartlockTask = mock()
     val params: AccountUi.Params = AccountUi.Params()
-    val loginActivityViewModel = LoginActivityViewModel(smartlockTask, URI.create("http://redirectUri"), params)
+    val loginActivityViewModel = LoginActivityViewModel(smartlockTask, mock(), params)
 
     "view model initialization" should {
         "add a listener to the smartlock resolving state" {


### PR DESCRIPTION
If there are no stored credentials, ensure the selected account identifier is prefilled.

### Testing instructions
1. Add at least one Google accounts to the device (Settings->Accounts->Add account->Google)
1. [Enable SmartLock in the example app](https://github.com/schibsted/account-sdk-android/blob/a9fb48dd847647aaa2bdacfa83edf9f96e9ce8f6/example/src/main/java/com/schibsted/account/example/MainActivity.java#L115).
1. Run the example app and press login.
1. Verify you're prompted for which account to continue with by SmartLock and select an account.
1. Verify the selected account identifier is pre-filled as the email address.