### PR TITLE
Focus on the input field and pop up keyboard when opening activity

### DIFF
--- a/ui/src/main/java/com/schibsted/account/ui/KeyboardController.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/KeyboardController.kt
@@ -6,6 +6,7 @@ package com.schibsted.account.ui
 import android.arch.lifecycle.MutableLiveData
 import android.content.Context
 import android.graphics.Rect
+import android.support.v4.app.FragmentActivity
 import android.support.v7.app.AppCompatActivity
 import android.view.View
 import android.view.ViewTreeObserver
@@ -18,6 +19,18 @@ class KeyboardController(private val activity: AppCompatActivity) : KeyboardList
     private val layoutListener: ViewTreeObserver.OnGlobalLayoutListener
     private var keyboardIsOpen: Boolean = false
     val keyboardVisibility = MutableLiveData<Boolean>()
+
+    companion object {
+        fun closeKeyboard(activity: FragmentActivity) {
+            val imm = activity.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+            imm.hideSoftInputFromWindow(activity.window.decorView.windowToken, 0)
+        }
+
+        fun showKeyboard(activity: FragmentActivity) {
+            val imm = activity.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+            imm.toggleSoftInput(InputMethodManager.SHOW_FORCED, 0)
+        }
+    }
 
     init {
         val keyboardThreshold = 150f
@@ -48,8 +61,7 @@ class KeyboardController(private val activity: AppCompatActivity) : KeyboardList
      * on the system implementation.
      */
     override fun closeKeyboard() {
-        val imm = activity.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-        imm.hideSoftInputFromWindow(activity.window.decorView.windowToken, 0)
+        Companion.closeKeyboard(activity)
     }
 
     /**

--- a/ui/src/main/java/com/schibsted/account/ui/login/BaseLoginActivity.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/login/BaseLoginActivity.kt
@@ -303,6 +303,7 @@ abstract class BaseLoginActivity : AppCompatActivity(), NavigationListener {
 
     override fun onPause() {
         super.onPause()
+        keyboardController.closeKeyboard()
         keyboardController.unregister(navigationController.currentFragment)
         navigationController.unregister()
     }

--- a/ui/src/main/java/com/schibsted/account/ui/login/screen/identification/ui/EmailIdentificationFragment.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/login/screen/identification/ui/EmailIdentificationFragment.kt
@@ -49,7 +49,7 @@ class EmailIdentificationFragment : AbstractIdentificationFragment(), Identifica
         super.onViewCreated(view, savedInstanceState)
         inputFieldView.inputField.requestFocus()
         if (inputFieldView.inputField.text.isNullOrBlank()) {
-            Logger.info(TAG, "Showing keyboard")
+            Logger.debug(TAG, "Showing keyboard")
             activity?.let { KeyboardController.showKeyboard(it) }
         }
     }

--- a/ui/src/main/java/com/schibsted/account/ui/login/screen/identification/ui/EmailIdentificationFragment.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/login/screen/identification/ui/EmailIdentificationFragment.kt
@@ -48,7 +48,10 @@ class EmailIdentificationFragment : AbstractIdentificationFragment(), Identifica
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         inputFieldView.inputField.requestFocus()
-        activity?.let { KeyboardController.showKeyboard(it) }
+        if (inputFieldView.inputField.text.isNullOrBlank()) {
+            Logger.info(TAG, "Showing keyboard")
+            activity?.let { KeyboardController.showKeyboard(it) }
+        }
     }
 
     public override fun prefillIdentifier(identifier: String?) {

--- a/ui/src/main/java/com/schibsted/account/ui/login/screen/identification/ui/EmailIdentificationFragment.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/login/screen/identification/ui/EmailIdentificationFragment.kt
@@ -14,6 +14,7 @@ import android.view.inputmethod.EditorInfo
 import com.schibsted.account.common.util.Logger
 import com.schibsted.account.network.response.ClientInfo
 import com.schibsted.account.ui.InternalUiConfiguration
+import com.schibsted.account.ui.KeyboardController
 import com.schibsted.account.ui.R
 import com.schibsted.account.ui.login.screen.identification.IdentificationContract
 import com.schibsted.account.ui.ui.component.SingleFieldView
@@ -42,6 +43,12 @@ class EmailIdentificationFragment : AbstractIdentificationFragment(), Identifica
         inputViewContainer.addView(inputFieldView)
         prefillIdentifier(uiConf.identifier)
         return view
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        inputFieldView.inputField.requestFocus()
+        activity?.let { KeyboardController.showKeyboard(it) }
     }
 
     public override fun prefillIdentifier(identifier: String?) {

--- a/ui/src/main/java/com/schibsted/account/ui/login/screen/identification/ui/MobileIdentificationFragment.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/login/screen/identification/ui/MobileIdentificationFragment.kt
@@ -14,6 +14,7 @@ import android.view.inputmethod.EditorInfo
 import com.schibsted.account.common.util.Logger
 import com.schibsted.account.network.response.ClientInfo
 import com.schibsted.account.ui.InternalUiConfiguration
+import com.schibsted.account.ui.KeyboardController
 import com.schibsted.account.ui.ui.component.PhoneInputView
 
 /**
@@ -35,6 +36,12 @@ class MobileIdentificationFragment : AbstractIdentificationFragment() {
 
         prefillIdentifier(uiConf.identifier)
         return view
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        inputFieldView.mobileNumberView.requestFocus()
+        activity?.let { KeyboardController.showKeyboard(it) }
     }
 
     override fun prefillIdentifier(identifier: String?) {

--- a/ui/src/main/java/com/schibsted/account/ui/login/screen/password/PasswordFragment.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/login/screen/password/PasswordFragment.kt
@@ -16,6 +16,7 @@ import com.schibsted.account.engine.input.Identifier
 import com.schibsted.account.model.error.ClientError
 import com.schibsted.account.persistence.LocalSecretsProvider
 import com.schibsted.account.ui.InternalUiConfiguration
+import com.schibsted.account.ui.KeyboardController
 import com.schibsted.account.ui.R
 import com.schibsted.account.ui.login.BaseLoginActivity
 import com.schibsted.account.ui.login.screen.LoginScreen
@@ -88,6 +89,9 @@ class PasswordFragment : FlowFragment<PasswordContract.Presenter>(), PasswordCon
             }
             return@setImeAction false
         }
+
+        password_input_view.requestFocus()
+        activity?.let { KeyboardController.showKeyboard(it) }
 
         remember_me.isChecked = true
 

--- a/ui/src/main/java/com/schibsted/account/ui/ui/component/PhoneInputView.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/ui/component/PhoneInputView.kt
@@ -33,7 +33,7 @@ class PhoneInputView
 @JvmOverloads constructor(context: Context?, attrs: AttributeSet? = null) : FieldView(context, attrs) {
 
     private val prefixView: EditText
-    private val mobileNumberView: SingleFieldView
+    val mobileNumberView: SingleFieldView
 
     init {
         val view = LayoutInflater.from(context).inflate(R.layout.schacc_phone_widget, this)


### PR DESCRIPTION
Focuses the input field and pops up the soft keyboard when the user enteres one of these three views:
- Username
- Password
- SMS (PhoneInputView)

Exception: if the user prefills the email field through the use of Google Smartlock.

In addition it makes sure we close the keyboard if the users minimizes the app while in input mode.

The solution is tested for all three views on two different phones:
- Samsung S8
- Huawei P20 Pro

PR replaces #366