### PR TITLE
Ignore SmartLock failure

### DIFF
--- a/smartlock/README.md
+++ b/smartlock/README.md
@@ -4,14 +4,14 @@ The smartlock module can be added to the UIs with the following dependency. The 
 implementation "com.schibsted.account:account-sdk-android-smartlock:<VERSION>"
 ```
 
-There are three smartlock modes:
-- SmartlockMode.DISABLED: The SDK will not attempt to log the user in with smartlock. 
-- SmartlockMode.ENABLED: The SDK will attempt to log the user in with smartlock. If it fails but smartlock managed to get the user identifier, the usual login flow will be launched 
-with identifier prefilled. For more information see [google smartlock flow](https://developers.google.com/identity/smartlock-passwords/android/overview)
-- SmartlockMode.FORCED: The SDK will attempt to log user in with and only with smartlock. 
-- SmartlockMode.FAILED: Tell the SDK that you've attempted to log in using smartlock, but that the user cancelled it or the attempt failed. This will allow the user to store new credentials.
+There are three SmartLock modes:
+- SmartlockMode.DISABLED: The SDK will not attempt to log the user in with SmartLock. 
+- SmartlockMode.ENABLED: The SDK will attempt to log the user in with SmartLock. If it fails but SmartLock managed to get the user identifier, the usual login flow will be launched 
+with identifier prefilled. For more information see [Google SmartLock flow](https://developers.google.com/identity/smartlock-passwords/android/overview)
+- SmartlockMode.FORCED: The SDK will attempt to log user in with and only with SmartLock. 
+- SmartlockMode.FAILED: Tell the SDK that you've attempted to log in using SmartLock, but that the user cancelled it or the attempt failed. This will allow the user to store new credentials.
 
-In any case of failure you will be notified in `onActivityResult` with the result code `AccountUi.SMARTLOCK_FAILED`. You might want to directly restart the flow, choosing to disabl e(`SmartlockMode.DISABLED`) SmartLock or tell the UIs that it failed (`SmartlockMode.FAILED`) for a seamless user experience. The former does not allow the user to store any new credentials, while the latter will allow hte user to store any new login credential they provide.
+In any case of failure when using the SmartlockMode.FORCED mode you will be notified in `onActivityResult` with the result code `AccountUi.SMARTLOCK_FAILED`. You might want to directly restart the flow, choosing to disable (`SmartlockMode.DISABLED`) SmartLock or tell the UIs that it failed (`SmartlockMode.FAILED`) for a seamless user experience. The former does not allow the user to store any new credentials, while the latter will allow the user to store any new login credential they provide.
 
 Please note that if you're using SmartLock, you need to handle user logouts. To do this, either set up the `SmartlockReceiver` (as seen below) to listen for logout events or manually call `Credentials.getClient(activity, CredentialsOptions.DEFAULT).disableAutoSignIn()`.
 

--- a/ui/src/main/java/com/schibsted/account/ui/login/BaseLoginActivity.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/login/BaseLoginActivity.kt
@@ -184,6 +184,10 @@ abstract class BaseLoginActivity : AppCompatActivity(), NavigationListener {
                         finish()
                     }
                 }
+                is SmartlockTask.SmartLockResult.NoValue -> {
+                    Logger.info(TAG, "Smartlock login failed or was cancelled - smartlockController mode ${params.smartLockMode.name}")
+                    progressBar.visibility = View.GONE
+                }
             }
         })
 

--- a/ui/src/main/java/com/schibsted/account/ui/smartlock/SmartlockTask.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/smartlock/SmartlockTask.kt
@@ -12,7 +12,7 @@ class SmartlockTask(private val smartlockMode: SmartlockMode) {
     sealed class SmartLockResult {
         data class Success(val requestCode: Int, val credentials: Parcelable) : SmartLockResult()
         data class Failure(val resultCode: Int) : SmartLockResult()
-        data class NoValue(val resultCode: Int): SmartLockResult()
+        data class NoValue(val resultCode: Int) : SmartLockResult()
     }
 
     fun initializeSmartlock(isSmartlockRunning: Boolean, isSmartlockAvailable: Boolean = SmartlockController.isSmartlockAvailable()): ObservableField<Boolean> {

--- a/ui/src/main/java/com/schibsted/account/ui/smartlock/SmartlockTask.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/smartlock/SmartlockTask.kt
@@ -12,6 +12,7 @@ class SmartlockTask(private val smartlockMode: SmartlockMode) {
     sealed class SmartLockResult {
         data class Success(val requestCode: Int, val credentials: Parcelable) : SmartLockResult()
         data class Failure(val resultCode: Int) : SmartLockResult()
+        data class NoValue(val resultCode: Int): SmartLockResult()
     }
 
     fun initializeSmartlock(isSmartlockRunning: Boolean, isSmartlockAvailable: Boolean = SmartlockController.isSmartlockAvailable()): ObservableField<Boolean> {
@@ -36,10 +37,18 @@ class SmartlockTask(private val smartlockMode: SmartlockMode) {
                         }
                     }
                 }
-                return ObservableField(SmartLockResult.Failure(resultCode))
-            } ?: return ObservableField(SmartLockResult.Failure(resultCode))
+                return nonSuccessResult(resultCode)
+            } ?: return nonSuccessResult(resultCode)
         } else {
-            return ObservableField(SmartLockResult.Failure(resultCode))
+            return nonSuccessResult(resultCode)
+        }
+    }
+
+    private fun nonSuccessResult(resultCode: Int): ObservableField<SmartLockResult> {
+        return if (smartlockMode == SmartlockMode.FORCED) {
+            ObservableField(SmartLockResult.Failure(resultCode))
+        } else {
+            ObservableField(SmartLockResult.NoValue(resultCode))
         }
     }
 }


### PR DESCRIPTION
To avoid unnecessarily requiring the login activity to be restarted if
SmartLock failed or was cancelled.

### Testing instructions
See #405. 