### PR TITLE
Fix #414: Resolve SmartLock flow when it's cancelled.

### DIFF
--- a/common/src/main/java/com/schibsted/account/common/smartlock/SmartLockCallback.kt
+++ b/common/src/main/java/com/schibsted/account/common/smartlock/SmartLockCallback.kt
@@ -10,4 +10,5 @@ interface SmartLockCallback {
     fun onHintRetrieved(id: String)
     fun onCredentialDeleted()
     fun onFailure()
+    fun onNoValue()
 }

--- a/ui/src/main/java/com/schibsted/account/ui/login/BaseLoginActivity.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/login/BaseLoginActivity.kt
@@ -187,6 +187,7 @@ abstract class BaseLoginActivity : AppCompatActivity(), NavigationListener {
                 is SmartlockTask.SmartLockResult.NoValue -> {
                     Logger.info(TAG, "Smartlock login failed or was cancelled - smartlockController mode ${params.smartLockMode.name}")
                     progressBar.visibility = View.GONE
+                    viewModel.smartlockReceiver.onNoValue()
                 }
             }
         })

--- a/ui/src/main/java/com/schibsted/account/ui/smartlock/SmartlockReceiver.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/smartlock/SmartlockReceiver.kt
@@ -35,4 +35,9 @@ class SmartlockReceiver(private val loginActivityViewModel: LoginActivityViewMod
         isSmartlockResolving.value = false
         loginActivityViewModel.smartlockResult.value = SmartlockTask.SmartLockResult.Failure(Activity.RESULT_CANCELED)
     }
+
+    override fun onNoValue() {
+        isSmartlockResolving.value = false
+        loginActivityViewModel.smartlockCredentials.value = null
+    }
 }


### PR DESCRIPTION
By marking SmartLock as done resolving when no value was retrieved, the
login flow is able to continue instead of hopelessly waiting for
SmartLock to finish (which it already has).

## Testing instructions
1. See #414 (requires account added to the device).