### PR TITLE
Log tags must be hardcoded.

### DIFF
--- a/core/src/main/java/com/schibsted/account/AccountService.kt
+++ b/core/src/main/java/com/schibsted/account/AccountService.kt
@@ -65,7 +65,7 @@ class AccountService @JvmOverloads constructor(
     }
 
     companion object {
-        private val TAG = AccountService::class.java.simpleName
+        private const val TAG = "AccountService"
         internal var localBroadcastManager: LocalBroadcastManager? = null
             @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
             set

--- a/core/src/main/java/com/schibsted/account/ClientConfiguration.kt
+++ b/core/src/main/java/com/schibsted/account/ClientConfiguration.kt
@@ -41,7 +41,7 @@ data class ClientConfiguration(
     }
 
     companion object {
-        private val TAG = ClientConfiguration::class.java.simpleName
+        private const val TAG = "ClientConfiguration"
         private const val KEY_ID = "clientId"
         private const val KEY_SECRET = "clientSecret"
         private const val KEY_ENVIRONMENT = "environment"

--- a/core/src/main/java/com/schibsted/account/model/error/NetworkError.kt
+++ b/core/src/main/java/com/schibsted/account/model/error/NetworkError.kt
@@ -64,7 +64,7 @@ data class NetworkError(val code: Int, val type: String, val description: String
 
     companion object {
         private val PARSER = JsonParser()
-        private val TAG = NetworkError::class.java.simpleName
+        private const val TAG = "NetworkError"
         fun <T> fromResponse(response: Response<T>): NetworkError {
             require(!response.isSuccessful) { "Cannot parse SPiD error from a successful request" }
 

--- a/core/src/main/java/com/schibsted/account/network/AuthInterceptor.kt
+++ b/core/src/main/java/com/schibsted/account/network/AuthInterceptor.kt
@@ -159,6 +159,6 @@ class AuthInterceptor constructor(
             }
 
     companion object {
-        private val TAG = AuthInterceptor::class.java.simpleName
+        private const val TAG = "AuthInterceptor"
     }
 }

--- a/core/src/main/java/com/schibsted/account/network/NetworkCallback.kt
+++ b/core/src/main/java/com/schibsted/account/network/NetworkCallback.kt
@@ -59,7 +59,7 @@ internal abstract class NetworkCallback<T>(val intent: String) : Callback<T> {
     abstract fun onError(error: NetworkError)
 
     companion object {
-        private val TAG = NetworkCallback::class.java.simpleName
+        private const val TAG = "NetworkCallback"
         @JvmStatic
         fun <T> lambda(intent: String, errorFun: (NetworkError) -> Unit, successFun: (T) -> Unit): NetworkCallback<T> {
             return object : NetworkCallback<T>(intent) {

--- a/core/src/main/java/com/schibsted/account/persistence/EncryptionKeyProvider.kt
+++ b/core/src/main/java/com/schibsted/account/persistence/EncryptionKeyProvider.kt
@@ -17,21 +17,13 @@ import android.support.annotation.VisibleForTesting
 import android.util.Base64
 import com.schibsted.account.common.util.Logger
 import java.math.BigInteger
-import java.security.KeyFactory
-import java.security.KeyPair
-import java.security.KeyPairGenerator
-import java.security.KeyStore
-import java.security.KeyStoreException
+import java.security.*
 import java.security.spec.AlgorithmParameterSpec
 import java.security.spec.PKCS8EncodedKeySpec
 import java.security.spec.RSAKeyGenParameterSpec
 import java.security.spec.X509EncodedKeySpec
 import java.text.DateFormat
-import java.util.Calendar
-import java.util.Date
-import java.util.GregorianCalendar
-import java.util.SimpleTimeZone
-import java.util.TimeZone
+import java.util.*
 import java.util.concurrent.TimeUnit
 import javax.security.auth.x500.X500Principal
 
@@ -220,7 +212,7 @@ class EncryptionKeyProvider(private val appContext: Context) {
     }
 
     companion object {
-        private val TAG = EncryptionKeyProvider::class.java.simpleName
+        private const val TAG = "EncryptionKeyProvider"
 
         private const val KEY_ALIAS = "identityKeyAlias"
         private const val KEY_ALGORITHM_RSA = "RSA"

--- a/core/src/main/java/com/schibsted/account/persistence/PersistenceEncryption.kt
+++ b/core/src/main/java/com/schibsted/account/persistence/PersistenceEncryption.kt
@@ -14,7 +14,7 @@ import javax.crypto.KeyGenerator
 import javax.crypto.SecretKey
 import javax.crypto.spec.IvParameterSpec
 
-private val TAG = PersistenceEncryption::class.java.simpleName
+private const val TAG = "PersistenceEncryption"
 private const val RSA_TRANSFORM = "RSA/ECB/PKCS1Padding"
 private const val AES_TRANSFORM = "AES/CBC/PKCS5Padding"
 const val AES_ALG = "AES"

--- a/core/src/main/java/com/schibsted/account/persistence/SessionStorageDelegate.kt
+++ b/core/src/main/java/com/schibsted/account/persistence/SessionStorageDelegate.kt
@@ -224,7 +224,7 @@ internal class SessionStorageDelegate(
     }
 
     companion object {
-        private val TAG = SessionStorageDelegate::class.java.simpleName
+        private const val TAG = "SessionStorageDelegate"
         private const val EMPTY_JSON_ARRAY = "[]"
         private val GSON = Gson()
     }

--- a/core/src/main/java/com/schibsted/account/persistence/UserPersistenceReceiver.kt
+++ b/core/src/main/java/com/schibsted/account/persistence/UserPersistenceReceiver.kt
@@ -15,7 +15,7 @@ import com.schibsted.account.model.UserId
 import com.schibsted.account.session.User
 
 class UserPersistenceReceiver(appContext: Context) : BroadcastReceiver() {
-    private val TAG = UserPersistenceReceiver::class.java.simpleName
+    private val TAG = "UserPersistenceReceiver"
 
     private val userPersistence = UserPersistence(appContext)
     private val localBroadcastManager = LocalBroadcastManager.getInstance(appContext)

--- a/core/src/main/java/com/schibsted/account/persistence/UserPersistenceService.kt
+++ b/core/src/main/java/com/schibsted/account/persistence/UserPersistenceService.kt
@@ -14,7 +14,7 @@ import com.schibsted.account.common.util.Logger
 
 class UserPersistenceService : Service() {
     class Connection : ServiceConnection {
-        private val TAG = UserPersistenceService::class.java.simpleName
+        private val TAG = "UserPersistenceService"
 
         var service: UserPersistenceService? = null
             private set

--- a/core/src/main/java/com/schibsted/account/util/DateUtils.kt
+++ b/core/src/main/java/com/schibsted/account/util/DateUtils.kt
@@ -3,14 +3,12 @@ package com.schibsted.account.util
 import com.schibsted.account.common.util.Logger
 import java.text.ParseException
 import java.text.SimpleDateFormat
-import java.util.Calendar
-import java.util.Date
-import java.util.Locale
-import java.util.Random
+import java.util.*
 
 object DateUtils {
     private const val DATE_PARSING_FORMAT = "yyyy-MM-dd'T'HH:mm:ss"
-    private val TAG = DateUtils::class.java.simpleName
+    private const val TAG = "DateUtils"
+
     fun fromString(stringDate: String): Date? {
         var date: Date? = null
         try {

--- a/core/src/main/java/com/schibsted/account/util/DeepLink.kt
+++ b/core/src/main/java/com/schibsted/account/util/DeepLink.kt
@@ -81,7 +81,7 @@ sealed class DeepLink {
     }
 
     companion object {
-        protected val TAG = DeepLink::class.java.simpleName
+        protected const val TAG = "DeepLink"
         private const val SCOPE_SEPARATOR = "-"
     }
 }

--- a/core/src/main/java/com/schibsted/account/util/DeepLinkHandler.kt
+++ b/core/src/main/java/com/schibsted/account/util/DeepLinkHandler.kt
@@ -12,7 +12,7 @@ import com.schibsted.account.common.util.safeUrl
 import java.net.URI
 
 object DeepLinkHandler {
-    private val TAG = DeepLinkHandler::class.java.simpleName
+    private const val TAG = "DeepLinkHandler"
     const val PARAM_ACTION = "act"
 
     fun resolveDeepLink(dataString: String?): DeepLink? {

--- a/smartlock/src/main/java/com/schibsted/account/smartlock/SmartlockController.kt
+++ b/smartlock/src/main/java/com/schibsted/account/smartlock/SmartlockController.kt
@@ -7,11 +7,7 @@ import android.content.IntentSender
 import android.os.Parcelable
 import android.support.v7.app.AppCompatActivity
 import android.util.Log
-import com.google.android.gms.auth.api.credentials.Credential
-import com.google.android.gms.auth.api.credentials.CredentialRequest
-import com.google.android.gms.auth.api.credentials.Credentials
-import com.google.android.gms.auth.api.credentials.CredentialsOptions
-import com.google.android.gms.auth.api.credentials.IdentityProviders
+import com.google.android.gms.auth.api.credentials.*
 import com.google.android.gms.common.api.CommonStatusCodes
 import com.google.android.gms.common.api.ResolvableApiException
 import com.google.android.gms.tasks.OnCompleteListener
@@ -23,7 +19,7 @@ import com.schibsted.account.engine.input.Identifier
 class SmartlockController(private val activity: AppCompatActivity, private val smartLockCallback: SmartLockCallback) : Smartlock {
 
     companion object {
-        private val TAG = SmartlockController::class.java.simpleName
+        private const val TAG = "SmartlockController"
         /**
          * Request code to send when the user has to choose between multiple account the one to login with.
          */

--- a/ui/src/main/java/com/schibsted/account/ui/RequiredConfiguration.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/RequiredConfiguration.kt
@@ -9,7 +9,7 @@ import java.net.URI
 @Parcelize
 data class RequiredConfiguration(val redirectUri: URI, val clientName: String) : Parcelable {
     companion object {
-        private val TAG = RequiredConfiguration::class.java.simpleName
+        private const val TAG = "RequiredConfiguration"
         @JvmStatic
         @Throws(IllegalArgumentException::class)
         fun fromResources(applicationContext: Context): RequiredConfiguration {

--- a/ui/src/main/java/com/schibsted/account/ui/login/BaseLoginActivity.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/login/BaseLoginActivity.kt
@@ -37,12 +37,7 @@ import com.schibsted.account.engine.integration.InputProvider
 import com.schibsted.account.network.Environment
 import com.schibsted.account.network.response.ClientInfo
 import com.schibsted.account.persistence.LocalSecretsProvider
-import com.schibsted.account.ui.AccountUi
-import com.schibsted.account.ui.InternalUiConfiguration
-import com.schibsted.account.ui.KeyboardController
-import com.schibsted.account.ui.OptionalConfiguration
-import com.schibsted.account.ui.R
-import com.schibsted.account.ui.UiUtil
+import com.schibsted.account.ui.*
 import com.schibsted.account.ui.login.flow.password.FlowSelectionListener
 import com.schibsted.account.ui.login.flow.password.LoginContractImpl
 import com.schibsted.account.ui.login.flow.password.OneStepLoginContractImpl
@@ -67,7 +62,7 @@ import kotlin.properties.Delegates
 abstract class BaseLoginActivity : AppCompatActivity(), NavigationListener {
 
     companion object {
-        private val TAG = BaseLoginActivity::class.java.simpleName
+        private const val TAG = "BaseLoginActivity"
         private const val KEY_SCREEN = "SCREEN"
         const val EXTRA_USER = "USER_USER"
         const val KEY_SMARTLOCK_CREDENTIALS = "CREDENTIALS"

--- a/ui/src/main/java/com/schibsted/account/ui/login/LoginActivityViewModel.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/login/LoginActivityViewModel.kt
@@ -179,6 +179,6 @@ class LoginActivityViewModel(
     }
 
     companion object {
-        private val TAG = LoginActivityViewModel::class.java.simpleName
+        private const val TAG = "LoginActivityViewModel"
     }
 }

--- a/ui/src/main/java/com/schibsted/account/ui/login/flow/password/LoginContractImpl.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/login/flow/password/LoginContractImpl.kt
@@ -92,6 +92,6 @@ open class LoginContractImpl(private val loginActivity: BaseLoginActivity, priva
         })
     }
     companion object {
-        val TAG = LoginContractImpl::class.java.simpleName
+        const val TAG = "LoginContractImpl"
     }
 }

--- a/ui/src/main/java/com/schibsted/account/ui/login/screen/identification/ui/EmailIdentificationFragment.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/login/screen/identification/ui/EmailIdentificationFragment.kt
@@ -94,7 +94,7 @@ class EmailIdentificationFragment : AbstractIdentificationFragment(), Identifica
     }
 
     companion object {
-        private val TAG = EmailIdentificationFragment::class.java.simpleName
+        private const val TAG = "EmailIdentificationFragment"
         /**
          * provide a new instance of this [Fragment]
          *

--- a/ui/src/main/java/com/schibsted/account/ui/login/screen/identification/ui/MobileIdentificationFragment.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/login/screen/identification/ui/MobileIdentificationFragment.kt
@@ -83,7 +83,7 @@ class MobileIdentificationFragment : AbstractIdentificationFragment() {
     }
 
     companion object {
-        private val TAG = MobileIdentificationFragment::class.java.simpleName
+        private const val TAG = "MobileIdentificationFragment"
         /**
          * provide a new instance of this [Fragment]
          *

--- a/ui/src/main/java/com/schibsted/account/ui/login/screen/onesteplogin/OneStepLoginFragment.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/login/screen/onesteplogin/OneStepLoginFragment.kt
@@ -316,7 +316,7 @@ class OneStepLoginFragment : FlowFragment<OneStepLoginContract.Presenter>(), One
     }
 
     companion object {
-        private val TAG = OneStepLoginFragment::class.java.simpleName
+        private const val TAG = "OneStepLoginFragment"
         const val KEY_CLIENT_INFO = "KEY_CLIENT_INFO"
         /**
          * provide a new instance of this [Fragment]

--- a/ui/src/main/java/com/schibsted/account/ui/navigation/Navigation.kt
+++ b/ui/src/main/java/com/schibsted/account/ui/navigation/Navigation.kt
@@ -216,6 +216,6 @@ class Navigation(
     }
 
     companion object {
-        private val TAG = Navigation::class.java.simpleName
+        private const val TAG = "Navigation"
     }
 }


### PR DESCRIPTION
`SomeClass::class.java.simpleName` should not be used when code might be proguarded. Proguard renames classes, making logs gibberish.

PS: I see some files are shown with large diffs. No clue why. This whole PR contains only one actual change - replacing `::class.java.simpleName` with literal strings.