### PR TITLE
Force RSA key refresh on upgrade to v1.11.2

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -7,7 +7,6 @@ if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ ! -z "$TRAVIS_TAG" ]; then
     ./gradlew :core:bintrayUpload
     ./gradlew :ui:bintrayUpload
     ./gradlew :smartlock:bintrayUpload
-    ./deploy_docs.sh
 else
     echo "Not publishing any releases."
     echo "Branch is $TRAVIS_BRANCH and tag is $TRAVIS_TAG"


### PR DESCRIPTION
The branch is just for releasing a hotfix for 1.11.2. There are no plans to merge it to master.