### PR TITLE
Configure Kotlin in each related project

### DIFF
--- a/buildSrc/src/main/java/SharedConfigurationPlugin.kt
+++ b/buildSrc/src/main/java/SharedConfigurationPlugin.kt
@@ -11,7 +11,6 @@ import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.testing.Test
 import org.gradle.kotlin.dsl.*
 import org.jetbrains.dokka.gradle.DokkaAndroidTask
-import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
 import java.util.*
 
 /**
@@ -40,7 +39,6 @@ class SharedConfigurationPlugin: Plugin<Project> {
 
     private fun Project.configureAndroid() = run {
         apply(plugin="com.android.library")
-        apply(plugin="org.jetbrains.kotlin.android")
 
         android {
             buildToolsVersion("29.0.2")
@@ -55,11 +53,6 @@ class SharedConfigurationPlugin: Plugin<Project> {
 
             lintOptions {
                 isAbortOnError = false
-            }
-
-            kotlinOptions {
-                apiVersion = "1.3"
-                languageVersion = "1.3"
             }
 
             dexOptions {
@@ -167,9 +160,6 @@ class SharedConfigurationPlugin: Plugin<Project> {
 
     private fun Project.android(configure: LibraryExtension.() -> Unit): Unit =
             (this as ExtensionAware).extensions.configure("android", configure)
-
-    private fun LibraryExtension.kotlinOptions(configure: KotlinJvmOptions.() -> Unit): Unit =
-            (this as ExtensionAware).extensions.configure("kotlinOptions", configure)
 
     private fun Project.publishing(configure: PublishingExtension.() -> Unit): Unit =
             (this as ExtensionAware).extensions.configure("publishing", configure)

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -2,6 +2,7 @@ import org.jetbrains.kotlin.config.KotlinCompilerVersion
 
 plugins {
     `shared-configuration`
+    kotlin("android")
 }
 
 description = "The common module for the Schibsted Account SDK"
@@ -10,10 +11,14 @@ android {
     defaultConfig {
         consumerProguardFiles("common-rules.pro")
     }
+    kotlinOptions {
+        apiVersion = "1.3"
+        languageVersion = "1.3"
+    }
 }
 
 dependencies {
-    implementation(kotlin("stdlib", KotlinCompilerVersion.VERSION))
+    implementation(kotlin("stdlib-jdk7", KotlinCompilerVersion.VERSION))
     implementation(kotlin("reflect", KotlinCompilerVersion.VERSION))
 
     testImplementation("junit:junit:${Constants.Versions.JUNIT}")

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -2,6 +2,7 @@ import org.jetbrains.kotlin.config.KotlinCompilerVersion
 
 plugins {
     `shared-configuration`
+    kotlin("android")
     kotlin("android.extensions")
 }
 
@@ -12,6 +13,10 @@ android {
         consumerProguardFiles("core-rules.pro")
     }
     useLibrary("android.test.mock")
+    kotlinOptions {
+        apiVersion = "1.3"
+        languageVersion = "1.3"
+    }
 }
 
 androidExtensions {
@@ -19,14 +24,15 @@ androidExtensions {
 }
 
 dependencies {
+    implementation(kotlin("stdlib-jdk7", KotlinCompilerVersion.VERSION))
+    implementation(kotlin("reflect", KotlinCompilerVersion.VERSION))
+
     api(project(":common"))
 
     api("com.squareup.retrofit2:converter-gson:${Constants.Versions.RETROFIT}")
     implementation("com.squareup.retrofit2:retrofit:${Constants.Versions.RETROFIT}")
     implementation("com.android.support:support-annotations:${Constants.Versions.SUPPORT}")
     implementation("com.android.support:support-core-utils:${Constants.Versions.SUPPORT}")
-    implementation(kotlin("stdlib", KotlinCompilerVersion.VERSION))
-    implementation(kotlin("reflect", KotlinCompilerVersion.VERSION))
 
     testImplementation("junit:junit:${Constants.Versions.JUNIT}")
     testImplementation("io.kotlintest:kotlintest-runner-junit5:${Constants.Versions.KOTLINTEST_RUNNER_JUNIT5}") {

--- a/smartlock/build.gradle.kts
+++ b/smartlock/build.gradle.kts
@@ -2,6 +2,7 @@ import org.jetbrains.kotlin.config.KotlinCompilerVersion
 
 plugins {
     `shared-configuration`
+    kotlin("android")
 }
 
 description = "The Smartlock module for the Schibsted Account SDK"
@@ -10,17 +11,22 @@ android {
     defaultConfig {
         consumerProguardFiles("smartlock-rules.pro")
     }
+    kotlinOptions {
+        apiVersion = "1.3"
+        languageVersion = "1.3"
+    }
 }
 
 dependencies {
+    implementation(kotlin("stdlib-jdk7", KotlinCompilerVersion.VERSION))
+    implementation(kotlin("reflect", KotlinCompilerVersion.VERSION))
+
     implementation(project(":common"))
     implementation(project(":core"))
     implementation("com.android.support:appcompat-v7:${Constants.Versions.SUPPORT}")
     implementation("com.google.android.gms:play-services-auth:${Constants.Versions.PLAY_SERVICES_AUTH}") {
         exclude(group="com.android.support")
     }
-    implementation(kotlin("stdlib", KotlinCompilerVersion.VERSION))
-    implementation(kotlin("reflect", KotlinCompilerVersion.VERSION))
 }
 
 publishing {

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -2,6 +2,7 @@ import org.jetbrains.kotlin.config.KotlinCompilerVersion
 
 plugins {
     `shared-configuration`
+    kotlin("android")
     kotlin("android.extensions")
 }
 
@@ -17,17 +18,22 @@ android {
     }
     resourcePrefix("schacc_")
     useLibrary("android.test.mock")
+    kotlinOptions {
+        apiVersion = "1.3"
+        languageVersion = "1.3"
+    }
 }
 
 dependencies {
+    implementation(kotlin("stdlib-jdk7", KotlinCompilerVersion.VERSION))
+    implementation(kotlin("reflect", KotlinCompilerVersion.VERSION))
+
     api(project(":core"))
     compileOnly(project(":smartlock"))
 
     implementation("com.android.support:support-annotations:${Constants.Versions.SUPPORT}")
     implementation("com.android.support:design:${Constants.Versions.SUPPORT}")
     implementation("com.android.support.constraint:constraint-layout:${Constants.Versions.CONSTRAINT_LAYOUT}")
-    implementation(kotlin("stdlib", KotlinCompilerVersion.VERSION))
-    implementation(kotlin("reflect", KotlinCompilerVersion.VERSION))
     implementation("android.arch.lifecycle:extensions:${Constants.Versions.LIFECYCLE}")
 
     testImplementation("org.assertj:assertj-core:${Constants.Versions.ASSERTJ_CORE}")


### PR DESCRIPTION
For some reason IDEA doesn't resolve runCatching and a few other Kotlin functions. If I configure Kotlin in each individual project, they are resolved fine :(
This behavior is specific to Linux. I tested in other OS, like Windows - it is just fine.