### PR TITLE
Force RSA key refresh on upgrade to 1.12

### DIFF
--- a/core/src/androidTest/java/com/schibsted/account/persistence/EncryptionKeyProviderTest.kt
+++ b/core/src/androidTest/java/com/schibsted/account/persistence/EncryptionKeyProviderTest.kt
@@ -229,15 +229,26 @@ class EncryptionKeyProviderTest {
         val provider = EncryptionKeyProvider.create(appContext)
         provider.refreshKeyPair()
 
-        val expiration = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(90)
+        // 90 days is exactly the threshold when we consider the key too close to expiration:
+        val expiration = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(90) - 100L
         prefs.edit().putLong(KEY_EXPIRATION, expiration).commit()
+
+        assertTrue(provider.isKeyCloseToExpiration())
+    }
+
+    @Test
+    fun keyIsCloseToExpiration_whenExpirationDateUnknown() {
+        val provider = EncryptionKeyProvider.create(appContext)
+        provider.refreshKeyPair()
+
+        prefs.edit().remove(KEY_EXPIRATION).commit()
 
         assertTrue(provider.isKeyCloseToExpiration())
     }
 
     companion object {
         private const val FILENAME = "IDENTITY_KEYSTORE"
-        private const val KEY_EXPIRATION = "KEY_PAIR_VALID_UNTIL"
+        private const val KEY_EXPIRATION = "IDENTITY_KEY_EXPIRATION_DATE"
 
         fun assertEquals(expected: KeyPair?, actual: KeyPair?) {
             if (expected == null && actual == null) return

--- a/core/src/main/java/com/schibsted/account/persistence/EncryptionKeyProvider.kt
+++ b/core/src/main/java/com/schibsted/account/persistence/EncryptionKeyProvider.kt
@@ -90,7 +90,8 @@ private const val KEYSTORE_PROVIDER = "AndroidKeyStore"
 private const val PREFS_FILENAME = "IDENTITY_KEYSTORE"
 private const val PREFS_PRIVATE_KEY = "IDENTITY_PR_KEY_PAIR"
 private const val PREFS_PUBLIC_KEY = "IDENTITY_PU_KEY_PAIR"
-private const val PREFS_EXPIRATION = "KEY_PAIR_VALID_UNTIL"
+private const val PREFS_EXPIRATION = "IDENTITY_KEY_EXPIRATION_DATE"
+private const val UNKNOWN = 0L
 private const val NEVER = -1L
 
 private abstract class BaseProvider(
@@ -102,7 +103,7 @@ private abstract class BaseProvider(
     }
 
     protected var expiration: Long
-        get() = prefs.getLong(PREFS_EXPIRATION, NEVER)
+        get() = prefs.getLong(PREFS_EXPIRATION, UNKNOWN)
         set(value) = with(prefs.edit()) {
             putLong(PREFS_EXPIRATION, value)
             apply()
@@ -126,6 +127,7 @@ private abstract class BaseProvider(
         val exp = expiration
         val threshold = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(90)
         return when(exp) {
+            UNKNOWN -> true
             NEVER -> false
             else -> exp < threshold
         }


### PR DESCRIPTION
Just like we did for 1.11.2 but simpler.