### PR TITLE
Enable compatibility with Java 8 features.

### DIFF
--- a/buildSrc/src/main/java/SharedConfigurationPlugin.kt
+++ b/buildSrc/src/main/java/SharedConfigurationPlugin.kt
@@ -2,6 +2,7 @@ import com.android.build.gradle.LibraryExtension
 import com.jfrog.bintray.gradle.BintrayExtension
 import com.jfrog.bintray.gradle.tasks.BintrayUploadTask
 import org.gradle.api.DefaultTask
+import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.ExtensionAware
@@ -49,6 +50,11 @@ class SharedConfigurationPlugin: Plugin<Project> {
                 targetSdkVersion(28)
                 versionName = project.version.toString()
                 testInstrumentationRunner = "android.support.test.runner.AndroidJUnitRunner"
+            }
+
+            compileOptions {
+                sourceCompatibility = JavaVersion.VERSION_1_8
+                targetCompatibility = JavaVersion.VERSION_1_8
             }
 
             lintOptions {


### PR DESCRIPTION
Mockito-Kotlin 3.3.1 requires compatibility with Java 8 features. It is only relevant to instrumented tests which I forgot to run, of course.