### PR TITLE
Always overwrite HTTP Authorization header in AuthInterceptor.

### DIFF
--- a/core/src/main/java/com/schibsted/account/network/AuthInterceptor.kt
+++ b/core/src/main/java/com/schibsted/account/network/AuthInterceptor.kt
@@ -94,7 +94,7 @@ class AuthInterceptor constructor(
                 ?: throw AuthException("Cannot perform authenticated request (ReqId:$reqId) when the user is logged out")
         val request = with(originalRequest.newBuilder()) {
             if (urlInWhitelist(originalUrl)) {
-                addHeader("Authorization", token.bearerAuthHeader())
+                header("Authorization", token.bearerAuthHeader())
             }
             build()
         }


### PR DESCRIPTION
The access token is already explicitly defined in the API call methods,
so it should be overwritten and not duplicated.
Otherwise it might cause requests to be rejected by
servers which strictly adhere to the HTTP spec (which prohibits multiple
Authorization headers).