### PR TITLE
Move decryption of deploy_key to deploy step on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,6 @@ android:
     - platform-tools
 git:
   depth: 500
-before_install:
-  - openssl aes-256-cbc -K $encrypted_de87219daf1c_key -iv $encrypted_de87219daf1c_iv -in deploy_key.enc -out deploy_key -d
-  - chmod 600 deploy_key
-  - eval `ssh-agent -s`
-  - ssh-add deploy_key
 before_script:
   # Since Gradle 5 we need extra memory for some tasks:
   - echo org.gradle.jvmargs=-Xmx2g > gradle.properties;
@@ -36,4 +31,5 @@ deploy:
     skip_cleanup: true
     script: ./release.sh
     on:
+      repo: schibsted/account-sdk-android
       tags: true

--- a/release.sh
+++ b/release.sh
@@ -1,14 +1,13 @@
 #!/bin/bash
 set -e
 
-if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ ! -z "$TRAVIS_TAG" ]; then
-    echo "We are on tag $TRAVIS_TAG, publishing releases."
-    ./gradlew :common:bintrayUpload
-    ./gradlew :core:bintrayUpload
-    ./gradlew :ui:bintrayUpload
-    ./gradlew :smartlock:bintrayUpload
-    ./deploy_docs.sh
-else
-    echo "Not publishing any releases."
-    echo "Branch is $TRAVIS_BRANCH and tag is $TRAVIS_TAG"
-fi
+openssl aes-256-cbc -K $encrypted_de87219daf1c_key -iv $encrypted_de87219daf1c_iv -in deploy_key.enc -out deploy_key -d
+chmod 600 deploy_key
+eval `ssh-agent -s`
+ssh-add deploy_key
+
+./gradlew :common:bintrayUpload
+./gradlew :core:bintrayUpload
+./gradlew :ui:bintrayUpload
+./gradlew :smartlock:bintrayUpload
+./deploy_docs.sh


### PR DESCRIPTION
Since Travis doesn't make encrypted data available for PRs from forks,
this change should enable the tests to still run for such PRs.

The deploy step is also restricted to only the main repo.