### PR TITLE
Center sch logo with client logo

### DIFF
--- a/ui/src/main/res/layout-land/schacc_abstract_identification_fragment_layout.xml
+++ b/ui/src/main/res/layout-land/schacc_abstract_identification_fragment_layout.xml
@@ -38,7 +38,8 @@
             app:layout_constraintEnd_toEndOf="parent"
             android:layout_marginEnd="@dimen/schacc_small_spacing"
             android:layout_marginRight="@dimen/schacc_small_spacing"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"/>
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <TextView

--- a/ui/src/main/res/layout-land/schacc_abstract_identification_fragment_layout.xml
+++ b/ui/src/main/res/layout-land/schacc_abstract_identification_fragment_layout.xml
@@ -24,7 +24,10 @@
             android:layout_alignParentStart="true"
             android:contentDescription="@null"
             android:layout_width="wrap_content"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            tools:src="@drawable/schacc_schibsted_logo_soft_black"
+            tools:layout_height="@dimen/schacc_logo_dimension"
+            tools:layout_width="@dimen/schacc_logo_dimension" />
 
         <ImageView
             android:id="@+id/schibsted_logo"

--- a/ui/src/main/res/layout-land/schacc_one_step_login_fragment_layout.xml
+++ b/ui/src/main/res/layout-land/schacc_one_step_login_fragment_layout.xml
@@ -39,7 +39,8 @@
             app:layout_constraintEnd_toEndOf="parent"
             android:layout_marginEnd="@dimen/schacc_small_spacing"
             android:layout_marginRight="@dimen/schacc_small_spacing"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <TextView

--- a/ui/src/main/res/layout-land/schacc_one_step_login_fragment_layout.xml
+++ b/ui/src/main/res/layout-land/schacc_one_step_login_fragment_layout.xml
@@ -24,6 +24,9 @@
             android:layout_alignParentLeft="true"
             android:layout_alignParentStart="true"
             android:contentDescription="@null"
+            tools:src="@drawable/schacc_schibsted_logo_soft_black"
+            tools:layout_height="@dimen/schacc_logo_dimension"
+            tools:layout_width="@dimen/schacc_logo_dimension"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content" />
 

--- a/ui/src/main/res/layout/schacc_abstract_identification_fragment_layout.xml
+++ b/ui/src/main/res/layout/schacc_abstract_identification_fragment_layout.xml
@@ -42,7 +42,8 @@
             app:layout_constraintEnd_toEndOf="parent"
             android:layout_marginEnd="@dimen/schacc_small_spacing"
             android:layout_marginRight="@dimen/schacc_small_spacing"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"/>
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <TextView

--- a/ui/src/main/res/layout/schacc_abstract_identification_fragment_layout.xml
+++ b/ui/src/main/res/layout/schacc_abstract_identification_fragment_layout.xml
@@ -29,6 +29,8 @@
             android:maxHeight="@dimen/schacc_logo_dimension"
             android:maxWidth="@dimen/schacc_logo_dimension"
             android:adjustViewBounds="true"
+            tools:layout_height="@dimen/schacc_logo_dimension"
+            tools:layout_width="@dimen/schacc_logo_dimension"
             tools:src="@drawable/schacc_schibsted_logo_soft_black" />
 
         <ImageView

--- a/ui/src/main/res/layout/schacc_one_step_login_fragment_layout.xml
+++ b/ui/src/main/res/layout/schacc_one_step_login_fragment_layout.xml
@@ -29,6 +29,8 @@
                 android:maxHeight="@dimen/schacc_logo_dimension"
                 android:maxWidth="@dimen/schacc_logo_dimension"
                 android:adjustViewBounds="true"
+                tools:layout_height="@dimen/schacc_logo_dimension"
+                tools:layout_width="@dimen/schacc_logo_dimension"
                 tools:src="@drawable/schacc_schibsted_logo_soft_black"/>
 
             <ImageView

--- a/ui/src/main/res/layout/schacc_one_step_login_fragment_layout.xml
+++ b/ui/src/main/res/layout/schacc_one_step_login_fragment_layout.xml
@@ -41,6 +41,7 @@
                 android:layout_height="wrap_content"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
                 android:layout_marginEnd="@dimen/schacc_small_spacing"
                 android:layout_marginRight="@dimen/schacc_small_spacing"/>
         </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
When client logo (on the left) is bigger (and can be up to 150dp) than Schibsted logo  - Schibsted logo (on right) gets misaligned - glued to the top.

BEFORE:
![image](https://user-images.githubusercontent.com/5023050/106913650-80996a00-6704-11eb-8953-c39cb4a70073.png)

When this PR is merged it will be nicely centered.
AFTER:
![image](https://user-images.githubusercontent.com/5023050/106913849-bb9b9d80-6704-11eb-8413-69fd3d342c9a.png)
