### PR TITLE
NestedScrollView must have only one child fix

### DIFF
--- a/buildSrc/src/main/java/Constants.kt
+++ b/buildSrc/src/main/java/Constants.kt
@@ -23,6 +23,5 @@ object Constants {
         const val ANDROIDX = "1.0.0"
         const val MATERIAL = "1.2.0"
         const val TEST_RUNNER = "1.2.0"
-        const val FRAGMENT = "1.3.0-rc02"
     }
 }

--- a/buildSrc/src/main/java/Constants.kt
+++ b/buildSrc/src/main/java/Constants.kt
@@ -23,5 +23,6 @@ object Constants {
         const val ANDROIDX = "1.0.0"
         const val MATERIAL = "1.2.0"
         const val TEST_RUNNER = "1.2.0"
+        const val FRAGMENT = "1.3.0-rc02"
     }
 }

--- a/buildSrc/src/main/java/Constants.kt
+++ b/buildSrc/src/main/java/Constants.kt
@@ -11,6 +11,7 @@ object Constants {
         const val ASSERTJ_CORE = "3.15.0"
         const val CONSTRAINT_LAYOUT = "1.1.3"
         const val LIFECYCLE = "2.0.0"
+        const val FRAGMENT = "1.2.0"
         const val JUNIT = "4.12"
         const val KOTLINTEST_RUNNER_JUNIT5 = "3.4.2"
         const val KOTLINX_COROUTINES_CORE = "1.3.3"

--- a/example/src/main/java/com/schibsted/account/example/MainActivity.java
+++ b/example/src/main/java/com/schibsted/account/example/MainActivity.java
@@ -127,11 +127,12 @@ public class MainActivity extends AppCompatActivity {
             button.setEnabled(false);
             button.setText(R.string.example_app_loading_info);
 
-            final Intent intent = AccountUi.getCallingIntent(getApplicationContext(), AccountUi.FlowType.ONE_STEP_PASSWORD,
-                    new AccountUi.Params.Builder()
-                            .teaserText(getString(R.string.example_teaser_text))
-                            .smartLockMode(SmartlockMode.DISABLED).build());
-            startActivityForResult(intent, PASSWORD_REQUEST_CODE);
+            Intent passwordActivityIntent = AccountUi.getCallingIntent(
+                    MainActivity.this,
+                    AccountUi.FlowType.PASSWORD,
+                    new AccountUi.Params.Builder().build()
+            );
+            startActivityForResult(passwordActivityIntent, 12);
         }
     };
 

--- a/example/src/main/java/com/schibsted/account/example/MainActivity.java
+++ b/example/src/main/java/com/schibsted/account/example/MainActivity.java
@@ -127,12 +127,11 @@ public class MainActivity extends AppCompatActivity {
             button.setEnabled(false);
             button.setText(R.string.example_app_loading_info);
 
-            Intent passwordActivityIntent = AccountUi.getCallingIntent(
-                    MainActivity.this,
-                    AccountUi.FlowType.PASSWORD,
-                    new AccountUi.Params.Builder().build()
-            );
-            startActivityForResult(passwordActivityIntent, 12);
+            final Intent intent = AccountUi.getCallingIntent(getApplicationContext(), AccountUi.FlowType.ONE_STEP_PASSWORD,
+                    new AccountUi.Params.Builder()
+                            .teaserText(getString(R.string.example_teaser_text))
+                            .smartLockMode(SmartlockMode.DISABLED).build());
+            startActivityForResult(intent, PASSWORD_REQUEST_CODE);
         }
     };
 

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
     implementation("androidx.constraintlayout:constraintlayout:${Constants.Versions.CONSTRAINT_LAYOUT}")
     implementation("androidx.localbroadcastmanager:localbroadcastmanager:${Constants.Versions.ANDROIDX}")
     implementation("androidx.lifecycle:lifecycle-extensions:${Constants.Versions.LIFECYCLE}")
+    implementation("androidx.fragment:fragment:${Constants.Versions.FRAGMENT}")
 
     testImplementation("org.assertj:assertj-core:${Constants.Versions.ASSERTJ_CORE}")
     testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:${Constants.Versions.MOCKITO_KOTLIN}")

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -36,7 +36,6 @@ dependencies {
     implementation("androidx.constraintlayout:constraintlayout:${Constants.Versions.CONSTRAINT_LAYOUT}")
     implementation("androidx.localbroadcastmanager:localbroadcastmanager:${Constants.Versions.ANDROIDX}")
     implementation("androidx.lifecycle:lifecycle-extensions:${Constants.Versions.LIFECYCLE}")
-    implementation("androidx.fragment:fragment:${Constants.Versions.FRAGMENT}")
 
     testImplementation("org.assertj:assertj-core:${Constants.Versions.ASSERTJ_CORE}")
     testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:${Constants.Versions.MOCKITO_KOTLIN}")

--- a/ui/src/main/res/layout/schacc_abstract_identification_fragment_layout.xml
+++ b/ui/src/main/res/layout/schacc_abstract_identification_fragment_layout.xml
@@ -7,7 +7,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/identification_container"
     android:windowBackground="@color/schacc_grey"
-    android:layout_height="wrap_content"
+    android:layout_height="match_parent"
     android:layout_width="match_parent">
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/ui/src/main/res/layout/schacc_mobile_activity_layout.xml
+++ b/ui/src/main/res/layout/schacc_mobile_activity_layout.xml
@@ -48,11 +48,17 @@
         </com.google.android.material.appbar.AppBarLayout>
 
         <androidx.core.widget.NestedScrollView
-            android:id="@+id/fragment_container"
             android:background="@color/schacc_backgroundColor"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:fillViewport="true" />
+            android:fillViewport="true">
+
+            <androidx.fragment.app.FragmentContainerView
+                android:id="@+id/fragment_container"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"/>
+
+        </androidx.core.widget.NestedScrollView>
     </LinearLayout>
 
     <ProgressBar

--- a/ui/src/main/res/layout/schacc_password_fragment_layout.xml
+++ b/ui/src/main/res/layout/schacc_password_fragment_layout.xml
@@ -4,7 +4,7 @@
 
 <LinearLayout xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="match_parent"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical">


### PR DESCRIPTION
Hello!
We are a bit on a bleeding-edge when it comes to the AndroidX/Jetpack libraries. Recently, we upgraded the fragment library from 1.3.0-alpha06 to 1.3.0-rc02. Unfortunately, this new version is making account-sdk-android crash. We get `NestedScrollView` must have only one child when we click "Continue" after typing in our email. I found a solution that uses `androidx.fragment.app.FragmentContainerView`. I also had to update the fragment library from 1.1.0 to 1.2.0 to make it visible, but at least it isn't alpha or rc. :slightly_smiling_face: