### PR TITLE
Treat 'invalid_grant' token response as logout signal.

### DIFF
--- a/core/src/main/java/com/schibsted/account/session/User.kt
+++ b/core/src/main/java/com/schibsted/account/session/User.kt
@@ -133,7 +133,8 @@ class User(token: UserToken, val isPersistable: Boolean) : Parcelable {
             true
         } else {
             Logger.verbose("User token refreshing failed")
-            if (listOf(401, 403).contains(resp.code())) {
+            val invalidRefreshToken = resp.code() == 400 && resp.errorBody()?.string()?.contains("invalid_grant") == true
+            if (invalidRefreshToken || listOf(401, 403).contains(resp.code())) {
                 Logger.verbose("Logging out user")
                 this@User.token = null
 


### PR DESCRIPTION
When the refresh token is invalid (expired, user has logged out, etc), 400 Bad Request with `"error": "invalid_grant"` is returned as response. So we should treat that as a logout.